### PR TITLE
カード風のリンクを追加する

### DIFF
--- a/content/docs/permissions.md
+++ b/content/docs/permissions.md
@@ -71,4 +71,8 @@ $ sisakulint -ignore expressions -debug
 
 I was able to get the following error.Available values for whole permissions are "write-all", "read-all" or "none".
 
-[Permissions for the `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
+{{< popup_link href=https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token >}}
+Permissions for the <code>GITHUB_TOKEN</code>
+{{< /popup_link >}}
+
+{{< load_link >}}

--- a/layouts/shortcodes/load_link.html
+++ b/layouts/shortcodes/load_link.html
@@ -1,0 +1,94 @@
+<script>
+    'use strict';
+    const links = document.getElementsByClassName('popup-link');
+
+    async function fetchAndParseOGP(url) {
+        const response = await fetch(url);
+        const htmlString = await response.text();
+
+        // HTMLをDOMにパース
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(htmlString, 'text/html');
+
+        // OGPメタタグを抽出
+        const ogTags = {};
+        const metaTags = doc.querySelectorAll('meta[property^="og:"]');
+        
+        metaTags.forEach(tag => {
+            const property = tag.getAttribute('property');
+            const content = tag.getAttribute('content');
+            if (property && content) {
+                ogTags[property] = content;
+            }
+        });
+
+        const favicon = doc.querySelector('link[rel="icon"]');
+
+        if (favicon) {
+            const parsedURL = new URL(favicon.getAttribute('href'), url);
+            ogTags['favicon'] = parsedURL.href;
+        }
+        else {
+            const parsedURL = new URL(url);
+            ogTags['favicon'] = `${parsedURL.origin}/favicon.ico`;
+        }
+
+        return ogTags;
+    }
+
+    async function sanitizeOGP(ogp) {
+        const sanitizedOGP = {};
+        for (const key in ogp) {
+            sanitizedOGP[key] = ogp[key].replace(/<("[^"]*"|'[^']*'|[^'">])*>/g, '');
+        }
+        return sanitizedOGP;
+    }
+
+    async function createBlock(ogp, href, descText) {
+        const block = document.createElement('div');
+        block.classList.add('popup-ogp');
+        sanitizeOGP(ogp);
+
+        block.innerHTML = `
+            <a href="${href}" style="display: flex; align-items: center; text-decoration: none; color: inherit;"> 
+                <img src="${ogp['og:image']}" alt="${ogp['og:title']}" style="max-width: 100px; margin-right: 15px;">
+                <div style="flex-grow: 1; overflow: hidden;">
+                    <h3 style="margin: 0; color: inherit;">${ogp['og:title']}</h3>
+                    <p style="margin: 0; color: inherit;">${descText}</p>
+                    <div style="display: flex; align-items: center; margin-top: 5px; overflow: hidden;">
+                        <img src="${ogp['favicon']}" alt="favicon" style="width: 16px; height: 16px; margin-right: 8px;">
+                        <p style="margin: 0; color: inherit; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-width: calc(100% - 24px);">
+                            ${href}
+                        </p>
+                    </div>
+                </div>
+            </a>
+        `;
+
+        block.style.border = '1px solid #ccc';
+        block.style.padding = '10px';
+        block.style.width = '100%';
+        block.style.height = 'auto';
+
+        return block;
+    }
+
+
+
+    for (let i = 0; i < links.length; i++) {
+        try {
+            const a = links[i].getElementsByTagName('a')[0];
+            fetchAndParseOGP(a.href).then(async(ogp) => {
+                console.log(ogp);
+                const block =await createBlock(ogp,a.href,a.innerHTML);
+                links[i].removeChild(a);
+                links[i].appendChild(block);
+            }).catch((error) => {
+                console.error(error);
+            });
+        }
+        catch (error) {
+            console.error(error);
+        }
+    }
+</script>

--- a/layouts/shortcodes/popup_link.html
+++ b/layouts/shortcodes/popup_link.html
@@ -1,0 +1,6 @@
+{{- $link := .Get "href" -}}
+<div class="popup-link">
+    <a href="{{ $link }}" >
+        {{ .Inner }}
+    </a>
+</div>


### PR DESCRIPTION
ChatGPTをぶん回してカード風な見た目にできるようにしました
使い方は
```
{{< popup_link href=https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token >}}
Permissions for the <code>GITHUB_TOKEN</code>
{{< /popup_link >}}

{{< load_link >}}
```
個々のリンクについてはpopup_linkでリンクを設定し最後にload_linkで置換するスクリプトを読み込む。
注意点としてpopup_linkの内部はmarkdownが働かないのでhtmlでどうにかしてほしい
.mdは現在一箇所だけテスト用に変えただけなのでマージする前に実際に見てもらってどうか確認してもらいたし