### PR TITLE
fix: update module path to sisaku-security org

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sisakulint/sisakulint.github.io
+module github.com/sisaku-security/sisakulint.github.io
 
 go 1.23.0
 


### PR DESCRIPTION
## 概要
組織名が `sisakulint` から `sisaku-security` に変更されたため、go.mod の module path を更新します。

## 変更内容
- `go.mod`: module pathを `github.com/sisakulint/sisakulint.github.io` から `github.com/sisaku-security/sisakulint.github.io` に変更