### PR TITLE
docs: add privacy policy and terms of service

### DIFF
--- a/content/docs/legal/_index.md
+++ b/content/docs/legal/_index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Legal'
-date = 2024-12-28
+date = 2025-12-28
 weight = 100
 +++
 

--- a/content/docs/legal/_index.md
+++ b/content/docs/legal/_index.md
@@ -1,0 +1,12 @@
++++
+title = 'Legal'
+date = 2024-12-28
+weight = 100
++++
+
+# Legal Documents
+
+This section contains legal documents for sisakulint and sisakulint-agent.
+
+- [Privacy Policy]({{< relref "privacy.md" >}})
+- [Terms of Service]({{< relref "terms.md" >}})

--- a/content/docs/legal/privacy.md
+++ b/content/docs/legal/privacy.md
@@ -1,0 +1,70 @@
++++
+title = 'Privacy Policy'
+date = 2024-12-28
+weight = 1
++++
+
+# Privacy Policy
+
+**Last Updated: December 28, 2024**
+
+This Privacy Policy describes how sisakulint-agent ("we", "us", or "our") collects, uses, and shares information when you use our GitHub App.
+
+## Information We Collect
+
+### Repository Data
+When you install sisakulint-agent on your GitHub repository, we access the following data:
+- **Workflow files**: We read `.github/workflows/*.yml` and `.github/workflows/*.yaml` files to perform static analysis
+- **Pull request metadata**: We access pull request information to post review comments
+- **Issue comments**: We read and write issue comments to provide autofix functionality
+
+### Data We Do NOT Collect
+- We do **not** collect or store your source code beyond workflow files
+- We do **not** collect personal information such as email addresses or names
+- We do **not** store any repository data permanently
+- We do **not** track user behavior or analytics
+
+## How We Use Information
+
+The data we access is used solely for:
+1. **Static analysis**: Analyzing GitHub Actions workflow files for security issues
+2. **Providing feedback**: Posting review comments on pull requests with detected issues
+3. **Autofix functionality**: Suggesting and applying fixes for detected issues
+
+## Data Retention
+
+- We do **not** retain any repository data after analysis is complete
+- All processing is done in real-time during webhook events
+- No logs containing repository content are stored
+
+## Data Sharing
+
+We do **not** share, sell, or transfer any data to third parties.
+
+## Security
+
+We implement appropriate technical and organizational measures to protect your data:
+- All communications use HTTPS encryption
+- We follow GitHub's security best practices for GitHub Apps
+- Our application runs in isolated environments
+
+## Your Rights
+
+You can:
+- **Revoke access** at any time by uninstalling the GitHub App from your repository or organization
+- **Request information** about the data we process by contacting us
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. We will notify you of any changes by updating the "Last Updated" date at the top of this policy.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy, please:
+- Open an issue at [https://github.com/sisaku-security/sisakulint-agent/issues](https://github.com/sisaku-security/sisakulint-agent/issues)
+- Or contact the maintainers through the repository
+
+## Open Source
+
+sisakulint-agent is open source software. You can review our code at:
+- [https://github.com/sisaku-security/sisakulint-agent](https://github.com/sisaku-security/sisakulint-agent)

--- a/content/docs/legal/privacy.md
+++ b/content/docs/legal/privacy.md
@@ -1,12 +1,12 @@
 +++
 title = 'Privacy Policy'
-date = 2024-12-28
+date = 2025-12-28
 weight = 1
 +++
 
 # Privacy Policy
 
-**Last Updated: December 28, 2024**
+**Last Updated: December 28, 2025**
 
 This Privacy Policy describes how sisakulint-agent ("we", "us", or "our") collects, uses, and shares information when you use our GitHub App.
 
@@ -18,7 +18,7 @@ When you install sisakulint-agent on your GitHub repository, we access the follo
 - **Pull request metadata**: We access pull request information to post review comments
 - **Issue comments**: We read and write issue comments to provide autofix functionality
 
-### Data We Do NOT Collect
+### Users Data We Do NOT Collect
 - We do **not** collect or store your source code beyond workflow files
 - We do **not** collect personal information such as email addresses or names
 - We do **not** store any repository data permanently
@@ -67,4 +67,4 @@ If you have any questions about this Privacy Policy, please:
 ## Open Source
 
 sisakulint-agent is open source software. You can review our code at:
-- [https://github.com/sisaku-security/sisakulint-agent](https://github.com/sisaku-security/sisakulint-agent)
+- [https://github.com/ultra-supara/sisakulint-agent](https://github.com/ultra-supara/sisakulint-agent)

--- a/content/docs/legal/privacy.md
+++ b/content/docs/legal/privacy.md
@@ -66,5 +66,5 @@ If you have any questions about this Privacy Policy, please:
 
 ## Open Source
 
-sisakulint-agent is open source software. You can review our code at:
-- [https://github.com/ultra-supara/sisakulint-agent](https://github.com/ultra-supara/sisakulint-agent)
+sisakulint is open source software. You can review our code at:
+- [https://github.com/ultra-supara/sisakulint](https://github.com/ultra-supara/sisakulint)

--- a/content/docs/legal/privacy.md
+++ b/content/docs/legal/privacy.md
@@ -61,7 +61,7 @@ We may update this Privacy Policy from time to time. We will notify you of any c
 ## Contact Us
 
 If you have any questions about this Privacy Policy, please:
-- Open an issue at [https://github.com/sisaku-security/sisakulint-agent/issues](https://github.com/sisaku-security/sisakulint-agent/issues)
+- Open an issue at [https://github.com/ultra-supara/sisakulint/issues](https://github.com/ultra-supara/sisakulint/issues)
 - Or contact the maintainers through the repository
 
 ## Open Source

--- a/content/docs/legal/terms.md
+++ b/content/docs/legal/terms.md
@@ -1,12 +1,12 @@
 +++
 title = 'Terms of Service'
-date = 2024-12-28
+date = 2025-12-28
 weight = 2
 +++
 
 # Terms of Service
 
-**Last Updated: December 28, 2024**
+**Last Updated: December 28, 2025**
 
 Please read these Terms of Service ("Terms") carefully before using sisakulint-agent ("the Service").
 
@@ -24,7 +24,7 @@ sisakulint-agent is a GitHub App that provides:
 
 ## License
 
-sisakulint-agent is open source software released under the ISC License. The source code is available at [https://github.com/sisaku-security/sisakulint-agent](https://github.com/sisaku-security/sisakulint-agent).
+sisakulint is open source. See the [LICENSE file](https://github.com/ultra-supara/sisakulint/blob/main/LICENSE) for details.
 
 ## Use of Service
 
@@ -96,4 +96,4 @@ For questions about these Terms, please:
 
 sisakulint-agent uses the following technologies:
 - [Probot](https://probot.github.io/) - GitHub App framework
-- [sisakulint](https://github.com/sisaku-security/sisakulint) - Static analysis engine
+- [sisakulint](https://github.com/ultra-supara/sisakulint) - Static analysis engine

--- a/content/docs/legal/terms.md
+++ b/content/docs/legal/terms.md
@@ -1,0 +1,99 @@
++++
+title = 'Terms of Service'
+date = 2024-12-28
+weight = 2
++++
+
+# Terms of Service
+
+**Last Updated: December 28, 2024**
+
+Please read these Terms of Service ("Terms") carefully before using sisakulint-agent ("the Service").
+
+## Acceptance of Terms
+
+By installing or using sisakulint-agent, you agree to be bound by these Terms. If you do not agree to these Terms, do not install or use the Service.
+
+## Description of Service
+
+sisakulint-agent is a GitHub App that provides:
+- Static analysis of GitHub Actions workflow files
+- Security vulnerability detection in CI/CD configurations
+- Automated code review comments on pull requests
+- Autofix suggestions for detected issues
+
+## License
+
+sisakulint-agent is open source software released under the ISC License. The source code is available at [https://github.com/sisaku-security/sisakulint-agent](https://github.com/sisaku-security/sisakulint-agent).
+
+## Use of Service
+
+### Permitted Use
+You may use the Service for:
+- Analyzing your own repositories
+- Analyzing repositories you have permission to access
+- Educational and research purposes
+
+### Prohibited Use
+You may not:
+- Use the Service to access repositories without authorization
+- Attempt to circumvent any security measures
+- Use the Service for any unlawful purpose
+- Interfere with or disrupt the Service
+
+## Disclaimer of Warranties
+
+THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO:
+- Merchantability
+- Fitness for a particular purpose
+- Non-infringement
+- Accuracy or completeness of analysis results
+
+We do not guarantee that:
+- The Service will detect all security issues
+- The Service will be error-free or uninterrupted
+- Autofix suggestions will be correct in all cases
+
+**You are responsible for reviewing all changes suggested by the Service before applying them.**
+
+## Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL THE AUTHORS, COPYRIGHT HOLDERS, OR MAINTAINERS BE LIABLE FOR ANY:
+- Direct, indirect, incidental, special, or consequential damages
+- Loss of profits, data, or business opportunities
+- Damages arising from use or inability to use the Service
+
+This limitation applies regardless of the theory of liability (contract, tort, or otherwise).
+
+## Indemnification
+
+You agree to indemnify and hold harmless the maintainers and contributors from any claims, damages, or expenses arising from your use of the Service or violation of these Terms.
+
+## Changes to Service
+
+We reserve the right to:
+- Modify or discontinue the Service at any time
+- Update these Terms at any time
+
+Continued use of the Service after changes constitutes acceptance of the modified Terms.
+
+## Termination
+
+You may stop using the Service at any time by uninstalling the GitHub App.
+
+We may terminate or suspend your access to the Service at any time, without prior notice, for conduct that we believe violates these Terms or is harmful to other users or the Service.
+
+## Governing Law
+
+These Terms shall be governed by and construed in accordance with applicable open source software licensing principles.
+
+## Contact
+
+For questions about these Terms, please:
+- Open an issue at [https://github.com/sisaku-security/sisakulint-agent/issues](https://github.com/sisaku-security/sisakulint-agent/issues)
+
+## Acknowledgments
+
+sisakulint-agent uses the following technologies:
+- [Probot](https://probot.github.io/) - GitHub App framework
+- [sisakulint](https://github.com/sisaku-security/sisakulint) - Static analysis engine


### PR DESCRIPTION
## Summary

- プライバシーポリシーを追加 (`/docs/legal/privacy/`)
- 利用規約を追加 (`/docs/legal/terms/`)

GitHub Apps Marketplace申請に必要な法的ドキュメントです。

## 公開URL (マージ後)

- Privacy Policy: https://sisaku-security.github.io/lint/docs/legal/privacy/
- Terms of Service: https://sisaku-security.github.io/lint/docs/legal/terms/

  Privacy Policy
  - 収集するデータ（ワークフローファイル、PRメタデータ）
  - 収集しないデータ（ソースコード、個人情報）
  - データの使用目的と保持ポリシー
  - セキュリティ対策

  Terms of Service
  - サービス説明
  - 許可される/禁止される利用
  - 免責事項と責任制限
  - ISCライセンスへの言及

## Checklist

- [x] プライバシーポリシー作成
- [x] 利用規約作成
- [x] Hugoサイト構造に準拠