### PR TITLE
docs(selfhostedrunners): rewrite the page against the pinned implementation

### DIFF
--- a/content/docs/rules/selfhostedrunners.md
+++ b/content/docs/rules/selfhostedrunners.md
@@ -187,7 +187,7 @@ covers all of them.
 - [GitHub: About self-hosted runners — Self-hosted runner security](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
 - [GitHub: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
 - [CWE-250: Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html)
-  — a job on a self-hosted runner operates with the host's reach, where an ephemeral one would do
+- [CWE-269: Improper Privilege Management](https://cwe.mitre.org/data/definitions/269.html)
+- [OWASP CICD-SEC-1: Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
 - [OWASP CICD-SEC-7: Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)
-  — the pipeline's systems and how they are hardened, which is where the choice of runner sits
 - [Rule source (`v0.3.6`)](https://github.com/sisaku-security/sisakulint/blob/v0.3.6/pkg/core/selfhostedrunnersrule.go)

--- a/content/docs/rules/selfhostedrunners.md
+++ b/content/docs/rules/selfhostedrunners.md
@@ -3,209 +3,188 @@ title: "Self-Hosted Runners Rule"
 weight: 1
 ---
 
-### Self-Hosted Runners Rule Overview
+This page describes sisakulint [v0.3.6](https://github.com/sisaku-security/sisakulint/releases/tag/v0.3.6).
 
-This rule detects **use of self-hosted runners** which pose significant security risks in public repositories. Self-hosted runners can persist state between workflow runs, allowing attackers to execute arbitrary code via pull requests.
+## Overview
 
-### Security Impact
+`self-hosted-runner` detects jobs configured to run on a self-hosted runner. Self-hosted runners keep state between
+jobs, so using one in a workflow whose contents can be influenced from outside creates a path
+where what a previous run left behind is picked up by the next.
 
-**Severity: High (8/10)**
+This rule looks at `runs-on`, and at `strategy.matrix` when `runs-on` is a matrix expression.
+Neither who can start the workflow nor whether the runner is ephemeral enters the judgement.
 
-Self-hosted runners in public repositories pose significant infrastructure risks:
+## Detection Scope
 
-1. **Arbitrary Code Execution**: Any user opening a PR can execute code on your infrastructure
-2. **State Persistence**: Malware persists between workflow runs
-3. **Network Access**: Attackers can pivot to internal resources
-4. **Credential Theft**: Cached credentials and secrets exposed to attackers
+A job is reported when `runs-on` matches any of the following. Cases 1 to 3 produce one finding
+per job; case 4 produces one per matching matrix key, so a job can carry several.
 
-This vulnerability aligns with **CWE-250: Execution with Unnecessary Privileges** and **OWASP CI/CD Security Risk CICD-SEC-7: Insecure System Configuration**.
+1. **The label list contains `self-hosted`.** Case-insensitive. Other labels alongside it make
+   no difference (`[self-hosted, ephemeral]` is included).
+2. **`group` is non-empty.** Runner groups conventionally contain self-hosted runners, so this
+   is reported with a different message that names the group.
+3. **`runs-on` is a scalar, contains no expression, and equals `self-hosted`.**
+4. **`runs-on` is an expression, and some matrix key whose name appears in it has a value
+   containing `self-hosted`.** Array values are examined element by element. The key name is
+   matched as a substring of the expression, so a key named `run` matches
+   `${{ matrix.runner }}` — a job whose `runner` values are all GitHub-hosted is reported when
+   an unrelated key named `run` happens to hold `self-hosted`.
 
-**Vulnerable Example:**
+Not examined:
+
+- **`if:` conditions.** A job is reported even when a condition would prevent it from running.
+- **The trigger.** A workflow with only `push` is still reported.
+- **Whether the repository is public or private.** That cannot be determined from the workflow file.
+- **Additional labels such as `ephemeral`.** If `self-hosted` is present, it is reported.
+- **A matrix that is itself an expression**, and **a referenced key whose value is an expression.**
+  Those keys are skipped.
+- **Expressions other than `matrix.`.** `${{ inputs.runner }}` and `${{ vars.RUNNER }}` are not examined.
+
+This rule emits no severity. A finding carries the file position, the message, and the rule name only.
+
+## Remediation
+
+1. **Switch to a GitHub-hosted runner.** Setting `runs-on: ubuntu-latest` or similar clears the
+   finding. GitHub-hosted runners are destroyed after each job, so no state persists.
+
+2. **Adding `if:` or extra labels to silence the finding does not work.** This rule examines
+   neither (see Detection Scope). `[self-hosted, ephemeral]` and
+   `if: github.repository_owner == '...'` are both reported the same way.
+
+3. **If self-hosted is intended, suppress it in the tool rather than in the workflow.**
+   `sisakulint -ignore <regexp>` drops findings whose **rule name** matches — the flag's help
+   text says it matches error messages, but the implementation matches the rule name
+   (sisakulint#591). For cases 1 to 3 nothing about how the job is written will silence the
+   finding. Case 4 is the exception: renaming a matrix key so it is no longer a substring of the
+   `runs-on` expression removes the finding, which is a consequence of the matching being on
+   spelling rather than on the value actually used.
+
+Note that the `self-hosted-runner.labels` setting in the configuration file is not used by this
+rule (see Rule Specific Guide).
+
+## Example Workflow the Rule Detects
 
 ```yaml
 name: Build
-on: pull_request
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:
   build:
-    runs-on: self-hosted  # DANGEROUS in public repos!
+    # VULNERABLE: a self-hosted runner is reachable from a trigger that
+    # outside contributors can fire.
+    runs-on: self-hosted
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - run: npm ci && npm test
+      - name: Run tests
+        run: make test
 ```
 
-**Detection Output:**
+## Example Output
 
 ```bash
-vulnerable.yaml:6:5: self-hosted runner detected via direct label specification. Self-hosted runners in public repositories allow any user to run arbitrary code on your infrastructure. See https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security [self-hosted-runner]
-      6 |    runs-on: self-hosted
+.github/workflows/build.yaml:11:14: job "build" uses self-hosted runner (direct label specification). Self-hosted runners are dangerous in public repositories because they can persist state between workflow runs and allow arbitrary code execution from pull requests. Consider using GitHub-hosted runners or ephemeral self-hosted runners. See https://sisaku-security.github.io/lint/docs/rules/selfhostedrunners/ [self-hosted-runner]
+       11 👈|    runs-on: self-hosted
 ```
 
-### Security Background
+The renderer prints a third line under the finding (a column pointer, all spaces) that is
+omitted here. Nothing else is reported for this workflow — `self-hosted-runner` is the only rule
+that fires on it.
 
-#### What are Self-Hosted Runners?
+## Example Workflow the Rule Does Not Detect
 
-Self-hosted runners are machines you manage to run GitHub Actions workflows. Unlike GitHub-hosted runners, they:
+The same workflow with only `runs-on` changed. This rule reports nothing.
 
-- Persist between workflow runs
-- Can access your internal network
-- May contain sensitive data or credentials
-- Are not automatically cleaned between runs
-
-#### Why is this dangerous in public repos?
-
-| Risk Factor | Impact |
-|-------------|--------|
-| **Arbitrary Code Execution** | Anyone can open a PR and run code |
-| **State Persistence** | Malware persists between runs |
-| **Network Access** | Attacker accesses internal resources |
-| **Credential Theft** | Cached credentials exposed |
-| **Lateral Movement** | Pivot point into infrastructure |
-
-#### Attack Scenario
-
-```
-1. Public repo uses self-hosted runner
-2. Attacker forks repo
-3. Attacker modifies workflow to run malicious code
-4. Attacker opens PR
-5. Workflow triggers on self-hosted runner
-6. Malicious code executes:
-   - Installs backdoor
-   - Steals credentials from environment
-   - Accesses internal network
-   - Persists for future workflows
-```
-
-#### OWASP and CWE Mapping
-
-- **CWE-250**: Execution with Unnecessary Privileges
-- **CWE-269**: Improper Privilege Management
-- **OWASP Top 10 CI/CD Security Risks:**
-  - **CICD-SEC-1:** Insufficient Flow Control Mechanisms
-  - **CICD-SEC-7:** Insecure System Configuration
-
-### Detection Logic
-
-#### What Gets Detected
-
-1. **Direct self-hosted label**
-   ```yaml
-   runs-on: self-hosted
-   runs-on: [self-hosted, linux]
-   ```
-
-2. **Runner group usage**
-   ```yaml
-   runs-on:
-     group: my-runner-group
-   ```
-
-3. **Matrix with self-hosted**
-   ```yaml
-   strategy:
-     matrix:
-       runner: [self-hosted, ubuntu-latest]
-   runs-on: ${{ matrix.runner }}
-   ```
-
-4. **Expression containing self-hosted**
-   ```yaml
-   runs-on: ${{ contains(inputs.runner, 'self-hosted') && 'self-hosted' || 'ubuntu-latest' }}
-   ```
-
-#### Safe Patterns (NOT Detected)
-
-GitHub-hosted runners:
 ```yaml
-runs-on: ubuntu-latest
-runs-on: windows-latest
-runs-on: macos-latest
+name: Build
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    # SAFE: GitHub-hosted runners are destroyed after every job, so nothing
+    # persists between runs.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Run tests
+        run: make test
 ```
 
-### Remediation Steps
+## Security Impact
 
-1. **Use GitHub-hosted runners for public repos**
-   ```yaml
-   runs-on: ubuntu-latest
-   ```
+Self-hosted runners are not ephemeral by default. When a job ends, the filesystem, processes,
+and cached credentials remain, and the next job inherits them. When a workflow whose contents
+an outside contributor can influence runs on such a runner, two things follow.
 
-2. **If self-hosted is required, make repo private**
-   - Convert public repos to private
-   - Use GitHub Enterprise with restricted access
+- **Carry-over into later jobs.** Files written or executables installed by an attacker remain,
+  and another workflow's build uses them.
+- **Reach into the runner host.** A job is an ordinary process on the runner, so it operates
+  within whatever network reachability and credentials that host holds.
 
-3. **Implement runner isolation**
-   - Use ephemeral runners that are destroyed after each job
-   - Use container-based isolation
-   - Implement network segmentation
+GitHub itself advises against using self-hosted runners with public repositories (see References).
 
-4. **Restrict workflow triggers**
-   ```yaml
-   on:
-     pull_request_target:  # Runs on base, not fork
-       types: [labeled]
-   ```
+## Security Background
 
-### Best Practices
+A GitHub-hosted runner is a fresh virtual machine per job, destroyed when the job ends. That
+destruction is what makes running untrusted code harmless to what follows.
 
-1. **Never use self-hosted runners in public repos**
-   - This is GitHub's official recommendation
-   - Use GitHub-hosted runners instead
+A self-hosted runner has no such destruction. Making one ephemeral is a separate configuration
+and is not the default. "Self-hosted" and "ephemeral" are therefore distinct properties, and
+the workflow file cannot tell you the latter. That is why this rule reports on the former alone.
 
-2. **For private repos with self-hosted runners**
-   ```yaml
-   # Use ephemeral runners
-   runs-on: [self-hosted, ephemeral]
+## Attack Scenario
 
-   # Or use containers
-   container: node:18
-   ```
+1. An attacker opens a pull request. A workflow started by `pull_request_target` runs on a
+   self-hosted runner
+2. That workflow does something that depends on the PR's contents (running tests, invoking a
+   build script)
+3. The attacker's code runs on the runner and writes to the host filesystem
+4. Another workflow on the same runner reads or executes what was left behind
 
-3. **Implement runner security measures**
-   - Enable runner auto-updates
-   - Use dedicated runner accounts
-   - Implement network isolation
-   - Monitor runner activity
+There is a job boundary between 3 and 4, but on a self-hosted runner state does not vanish at
+that boundary.
 
-4. **Use larger GitHub-hosted runners**
-   - For more resources, use larger runners
-   - Available through GitHub Actions billing
+## Related Rules
 
-### Alternative Approaches
+- [untrusted-checkout]({{< ref "untrustedcheckout.md" >}}): detect checkouts of untrusted code
+- [dangerous-triggers]({{< ref "dangeroustriggersrulecritical.md" >}}): detect privileged triggers
+- [permissions]({{< ref "permissions.md" >}}): narrow the workflow's permissions
 
-1. **GitHub-hosted larger runners**
-   ```yaml
-   runs-on: ubuntu-latest-8-cores
-   ```
+## Rule Specific Guide
 
-2. **Self-hosted with strict controls**
-   ```yaml
-   # Only for internal workflows, not PRs
-   on:
-     push:
-       branches: [main]
+### `self-hosted-runner.labels` in the configuration file has no effect
 
-   jobs:
-     build:
-       if: github.repository_owner == 'your-org'
-       runs-on: self-hosted
-   ```
+The sisakulint configuration file contains this section.
 
-3. **Use pull_request_target with caution**
-   ```yaml
-   on:
-     pull_request_target:
-       types: [labeled]
+```yaml
+self-hosted-runner:
+  labels: []
+```
 
-   jobs:
-     build:
-       if: contains(github.event.pull_request.labels.*.name, 'safe-to-test')
-       runs-on: self-hosted
-   ```
+The default configuration file describes it as letting sisakulint verify that label settings
+are correct, but this value is not used by this rule. It is read only when stringifying the
+configuration and when regenerating the configuration file. Listing your own labels here does
+not change anything: a job containing `self-hosted` is reported just the same.
 
-### References
+### There are three message variants
 
-- [GitHub: Self-hosted runner security](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
+Cases 1 and 3 of Detection Scope share a message (containing `direct label specification`),
+case 2 uses a runner-group message, and case 4 uses a matrix message naming the key. The
+messages differ, but `-ignore` matches the rule name rather than the message, so one pattern
+covers all of them.
+
+## References
+
+- [GitHub: About self-hosted runners — Self-hosted runner security](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
 - [GitHub: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
-- [OWASP Top 10 CI/CD Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/)
-- [GitHub: Using larger runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners)
+- [OWASP: CI/CD Top 10 Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/)
+- [Rule source (`v0.3.6`)](https://github.com/sisaku-security/sisakulint/blob/v0.3.6/pkg/core/selfhostedrunnersrule.go)

--- a/content/docs/rules/selfhostedrunners.md
+++ b/content/docs/rules/selfhostedrunners.md
@@ -186,5 +186,8 @@ covers all of them.
 
 - [GitHub: About self-hosted runners — Self-hosted runner security](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
 - [GitHub: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
-- [OWASP: CI/CD Top 10 Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/)
+- [CWE-250: Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html)
+  — a job on a self-hosted runner operates with the host's reach, where an ephemeral one would do
+- [OWASP CICD-SEC-7: Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)
+  — the pipeline's systems and how they are hardened, which is where the choice of runner sits
 - [Rule source (`v0.3.6`)](https://github.com/sisaku-security/sisakulint/blob/v0.3.6/pkg/core/selfhostedrunnersrule.go)


### PR DESCRIPTION
## What

Rewrites `content/docs/rules/selfhostedrunners.md`. One file. The page URL and `weight` are
unchanged.

## How it was produced

Written from the implementation rather than edited from the current page:

1. `pkg/core/selfhostedrunnersrule.go` read in full at sisakulint
   `dea1408b296a54edc30206ee844daf5ea185b79e` (v0.3.6).
2. Every claim checked back against that source and against runs of the binary built from it.
3. The page's own two example workflows executed against that binary, and the output pasted
   verbatim.

## What was verified

- **Example Output is byte-identical** to what `dea1408b` prints for the page's own "Example
  Workflow the Rule Detects". The page states the one line it omits (the column pointer).
  `self-hosted-runner` is the only rule that fires on that workflow.
- The "Example Workflow the Rule Does Not Detect" reports **0** findings from this rule.
- `hugo` builds the site with this page in place — no `REF_NOT_FOUND`, and the set of generated
  pages is unchanged from `main`.

## What changed in substance

Against the page as it stands:

- **`Severity: High (8/10)` is dropped.** The tool prints no severity for this rule; a finding
  carries the file position, the message, and the rule name only.
- **The three "safe" examples are dropped.** Run against `dea1408b`, all three report one finding
  each — Best Practices item 2 (`ephemeral` label), Alternative Approaches item 2
  (`repository_owner` gate), Alternative Approaches item 3 (`pull_request_target` + label gate).
  The rule reads none of those; it reads `runs-on` and, when `runs-on` is a matrix expression,
  `strategy.matrix`.
- **Added — the matrix path.** A matrix key name is matched as a *substring* of the `runs-on`
  expression, so a key named `run` matches `${{ matrix.runner }}`: a job whose `runner` values
  are all GitHub-hosted is reported when an unrelated key happens to hold `self-hosted`. This
  path also reports once per matching key, so one job can carry several findings.
- **Added —** the `self-hosted-runner.labels` section in the configuration file is not read by
  this rule.
- **Added —** `-ignore` matches the **rule name**, not the message
  (sisaku-security/sisakulint#591).

## Relation to #8

#8 (`docs(rules): align 5 rule docs to actual code behavior`) was closed with "one open question
(rule severity framing) should be settled here" still at the top of its description. This PR
treats that question as settled by measurement: the tool emits no severity for this rule, so the
page does not state one. That is the first item above.

#8 also carried 16 files in one branch. This series goes one document per PR, so an unsettled
question stops that page rather than all of them.

## Residual risk

The text was produced with LLM assistance. The procedure above ties the factual claims to the
implementation and to real output, and the mechanical parts are checked automatically. Even so,
the possibility of errors in some wording cannot be completely excluded.

Corrections will be sent as follow-up PRs as they are found — four statements in this page's own
draft were caught and fixed that way before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
