### PR TITLE
docs(actionlist): rewrite the page against the pinned implementation

### DIFF
--- a/content/docs/rules/actionlist.md
+++ b/content/docs/rules/actionlist.md
@@ -1,182 +1,262 @@
 ---
 title: "Action List Rule"
 weight: 1
-# bookFlatSection: false
-# bookToc: true
-# bookHidden: false
-# bookCollapseSection: false
-# bookComments: false
-# bookSearchExclude: false
 ---
 
-### Action List Rule Overview
+This page describes sisakulint [v0.3.6](https://github.com/sisaku-security/sisakulint/releases/tag/v0.3.6).
 
-This rule enforces a whitelist of allowed GitHub Actions in your workflows. It helps prevent the use of unauthorized or potentially malicious third-party actions, which is a critical security practice for CI/CD pipelines.
+## Overview
 
-**IMPORTANT**: This rule **only activates when `action-list:` is defined in `.github/sisakulint.yaml`**. Without this configuration, all actions are permitted by default. To begin using this rule, you must either:
-1. Generate a configuration using `-generate-action-list` command (recommended for first-time setup)
-2. Manually define `action-list:` patterns in your configuration file
+Checks the actions referenced by `uses:` against a list in the configuration file. A reference
+matching none of the patterns in the list is reported.
 
-When `action-list:` is not configured, sisakulint will not check action references, allowing you to use any third-party actions without restrictions.
+**Nothing is reported without configuration.** The rule is registered unconditionally and runs on
+every workflow the tool manages to parse; with no `action-list` entries it allows every
+reference, so it reports nothing. It begins reporting once `action-list` holds at least one
+pattern.
 
-#### Key Features:
+The configuration is read from `.github/sisakulint.yaml`, or from `.github/sisakulint.yml` if
+the first is absent, or from the path given to `-config-file` — which need not be under
+`.github`, or even inside the repository.
 
-- **Opt-in Activation**: Rule only runs when `action-list:` is configured in `.github/sisakulint.yaml`
-- **Whitelist Enforcement**: Only actions matching configured patterns are allowed
-- **Wildcard Support**: Use `*` wildcards to match multiple versions (e.g., `actions/checkout@*`)
-- **Auto-generation**: Automatically generate whitelist from existing workflows
+## Detection Scope
 
-### Generating Action List Configuration (First-Time Setup)
+When `action-list` holds one or more patterns, every step's `uses:` value in a job is matched
+against all of them, and **a reference matching none of them produces one finding**.
 
-**Use this command when you don't have `action-list:` defined in `.github/sisakulint.yaml` yet.** This is the recommended way to create your initial whitelist configuration.
+Pattern matching works as follows.
 
-sisakulint provides a convenient command to automatically generate an action list configuration from your existing workflow files:
+- `*` is replaced by "any string"; every other character is treated literally, producing a
+  regular expression.
+- The match is anchored against **the whole `uses:` value**. What follows `@` is part of the
+  match too.
 
-```bash
-sisakulint -generate-action-list
-```
+Not examined:
 
-This command will:
-1. Scan all workflow files in `.github/workflows/`
-2. Extract all action references (e.g., `actions/checkout@v4`)
-3. Normalize them to patterns with wildcards (e.g., `actions/checkout@*`)
-4. Generate or update `.github/sisakulint.yaml` with the action list
+- **`run:` steps.** They reference no action, so they are out of scope.
+- **The contents of an action.** Only whether the reference matches the list. Trustworthiness is
+  not judged.
+- **Reusable workflows called with `jobs.<job_id>.uses`.** This rule walks the steps of a job.
+  A workflow called from the job itself is not matched against the list, and the actions used
+  inside that workflow are not reached either.
 
-**Once generated, the action-list rule will activate on your next `sisakulint` run.**
+References beginning with `docker://` and local actions inside the repository are `uses:` values
+too, so they are in scope.
 
-#### Example Output:
+This rule emits no severity. A finding carries the file position, the message, and the rule name only.
 
-```bash
-Generated action list configuration at .github/sisakulint.yaml
-Found 5 unique action patterns
-```
+## Remediation
 
-#### Generated Configuration Example:
+1. **To keep using the action, review it and add the narrowest pattern that covers it.** Look at
+   the provider, at what the step passes the action, and at what the job's `permissions:` grant
+   it; then write a pattern for that reference and no more. A full-length commit SHA matched
+   exactly is the narrowest form, and it rejects every other ref (see Security Background). Once
+   the reference matches, the finding clears — what the list records is the pattern, not the
+   review.
+
+2. **Do not forget the `@`.** The pattern `actions/checkout` does **not** match
+   `actions/checkout@v4`. To match including the version, write `actions/checkout@*`.
+
+   ```yaml
+   action-list:
+     - actions/checkout@*        # matches
+     - actions/checkout          # does not match (what follows @ is left over)
+   ```
+
+3. **To stop using it, remove the step or replace it with an action that is on the list.**
+
+Deleting the list, or emptying it, also clears findings, but that turns the rule off rather than
+allowing the reference.
+
+## Example Workflow the Rule Detects
+
+The example is a pair: a workflow and a configuration.
+
+`.github/sisakulint.yaml`:
 
 ```yaml
-# Configuration file for sisakulint
-# Auto-generated action list from existing workflow files
-
-# Allowed GitHub Actions (auto-generated from existing workflows)
 action-list:
   - actions/checkout@*
-  - actions/setup-go@*
-  - docker/build-push-action@*
-  - golangci/golangci-lint-action@*
+  - actions/setup-node@*
 ```
 
-### Pattern Matching
-
-The action list supports flexible pattern matching with wildcards:
-
-- **Version wildcards**: `actions/checkout@*` matches any version
-- **Exact matches**: `actions/checkout@v4` matches only v4
-- **Local paths**: `./local-action@v1` (preserved as-is)
-- **Docker images**: `docker://alpine:latest` (preserved as-is)
-
-### Example Workflow
-
-Consider the following workflow file:
+`.github/workflows/ci.yaml`:
 
 ```yaml
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [main]
 
 jobs:
-  lint:
-    name: Lint
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.21.4"
-      - uses: unauthorized/suspicious-action@v1
-        name: Run Suspicious Action
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # not covered by any pattern in action-list
+      - name: Publish coverage
+        uses: unknown-org/coverage-uploader@v1
 ```
 
-With the following `.github/sisakulint.yaml` configuration:
+## Example Output
+
+```bash
+.github/workflows/ci.yaml:16:9: action 'unknown-org/coverage-uploader@v1' is not in the whitelist in step 'Publish coverage' [action-list]
+       16 👈|      - name: Publish coverage
+```
+
+Only this rule's finding is shown; other rules report on the same run. A third line under each
+finding (a column pointer, all spaces) is omitted here.
+
+## Example Workflow the Rule Does Not Detect
+
+The same workflow with the referenced action replaced by one on the list, and a pattern added to
+the list. This rule reports nothing.
+
+`.github/sisakulint.yaml`:
 
 ```yaml
 action-list:
   - actions/checkout@*
-  - actions/setup-go@*
-  - golangci/golangci-lint-action@*
+  - actions/setup-node@*
+  - codecov/codecov-action@*
 ```
 
-### Example Output
+`.github/workflows/ci.yaml`:
 
-Running sisakulint will detect the unauthorized action:
+```yaml
+name: CI
 
-```bash
-$ sisakulint
+on:
+  push:
+    branches: [main]
 
-.github/workflows/ci.yaml:12:9: action 'unauthorized/suspicious-action@v1' is not in the whitelist in step 'Run Suspicious Action' [action-list]
-       12 👈|      - uses: unauthorized/suspicious-action@v1
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # covered by a pattern in action-list
+      - name: Publish coverage
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
 ```
 
-**Note**: This rule does not support auto-fixing. You must manually review and update workflow files to use only approved actions from your whitelist.
+## Security Impact
 
-### Feature Background
+An action referenced by `uses:` runs inside that job. It runs under the job's `GITHUB_TOKEN`
+permissions, and it receives whatever secrets, inputs, and environment variables the step hands
+it. What a given action can reach therefore depends on the job's `permissions:` and on what the
+step passes, not on the reference alone.
 
-#### Real-World Supply Chain Attack: tj-actions Breach
+What this rule provides is **a practice of limiting references to an explicit list**. A
+reference matching none of the patterns produces a finding, so where the exit status gates a
+merge, adding that reference has to be dealt with explicitly. How much that catches depends on
+how wide the patterns are: `actions/*` admits an unreviewed `actions/<anything>@...`, and `*`
+admits everything.
 
-This rule was created in response to recommendations from the **Black Hat USA 2025 presentation** on the tj-actions supply chain breach, which demonstrated the critical need for action governance:
+Being on the list does not mean the action is safe. The list is a set of allowed patterns, and
+`sisakulint -generate-action-list` will even build one from the references already in the
+repository's workflows — so it is not a record of what has been inspected, nor of what has been
+seen. A pattern can therefore cover a reference that no one has looked at, and the tool cannot
+tell the two apart.
 
-**The Incident:**
-- **tj-actions/changed-files**, a popular GitHub Action used in over 23,000 public repositories, was compromised
-- Attackers used "imposter commits" living in a fork to inject malicious code
-- The malicious payload downloaded a Python script to dump and exfiltrate CI/CD secrets
-- Traditional security tools failed to detect this sophisticated attack
+## Security Background
 
-**Recommendations**
-The presentation outlined four key security controls, with **"Enforce an Action Allowlist"** as a critical recommendation:
-1. Implement Security Monitoring for CI/CD Runners
-2. **Enforce an Action Allowlist** - Due to over 25,000 actions in GitHub Marketplace, organizations must curate and control which actions can be used
-3. Pin Actions to Specific Commit SHAs
-4. Develop an Incident Response Plan
+What a reference resolves to is not fixed by the reference alone. A tag can be repointed after it
+is written, so the same `@v1` can come to mean different contents.
 
-**Why Action Allowlist Matters**
-With over 25,000 actions available in the GitHub Marketplace, it's impossible to manually vet every action. An allowlist approach ensures:
-- Only pre-approved, vetted actions can be used in your workflows
-- New or compromised actions are blocked by default
-- Organizations maintain control over their CI/CD supply chain
+Supply-chain management therefore has two axes: **whose actions you use** (this rule) and
+**whether you pin the version** (`commit-sha`). The two overlap only where a pattern names the
+version: `actions/*` leaves the version free, while `actions/checkout@<full sha>` as a pattern
+rejects any other ref. A provider-only pattern cannot prevent a version being swapped, and
+pinning alone cannot prevent unknown providers being added.
 
-#### Common Security Risks
+## Attack Scenario
 
-As the complexity of CI/CD pipelines grows, the number of third-party actions used in workflows increases significantly. This introduces several security risks:
+1. A change that adds a dependency also adds one `uses:` line for a new action
+2. Neither the provider nor the contents of that action have been reviewed
+3. When the job runs, the action executes within that job's permissions and credentials
+4. Without a list, that one line passes among the other changes
 
-1. **Supply Chain Attacks**: Malicious actors can compromise popular actions or create imposter actions with similar names (as seen in the tj-actions breach)
-2. **Credential Theft**: Unauthorized actions may exfiltrate secrets or credentials
-3. **Code Injection**: Actions can inject malicious code into your build process
-4. **Compliance Violations**: Using unvetted actions may violate organizational security policies
+With a list, step 4 produces a finding **when the new reference matches none of the patterns**,
+making the decision to add it explicit. A pattern such as `actions/*` — or `*` — already covers
+the new reference, and nothing is reported.
 
-The action-list rule addresses these risks by implementing a whitelist approach:
+## Related Rules
 
-- **Explicit Allow**: Only pre-approved actions can be used
-- **Version Control**: Track approved actions in version control
-- **Team Collaboration**: Share and review approved actions across teams
-- **Automated Enforcement**: Catch unauthorized actions in CI/CD
+- [commit-sha]({{< ref "commitsharule.md" >}}): pin an action's version to a commit SHA
+- [known-vulnerable-actions]({{< ref "knownvulnerableactions.md" >}}): detect known vulnerable actions
+- [archived-uses]({{< ref "archiveduses.md" >}}): detect references to archived actions
 
-This aligns with OWASP CI/CD Security Risk **CICD-SEC-8: Ungoverned Usage of 3rd Party Services**, specifically addressing the governance of third-party GitHub Actions. While CICD-SEC-8 covers a broader range of third-party integrations (GitHub Apps, OAuth, webhooks, etc.), this rule focuses on controlling and monitoring third-party action usage in workflows, which is a critical subset of the overall risk.
+## Rule Specific Guide
 
-### Configuration Best Practices
+### There is no denying side
 
-1. **Start with generation**: Use `-generate-action-list` to create an initial whitelist when `.github/sisakulint.yaml` doesn't have `action-list:` configured yet
-2. **Review and refine**: Manually review the generated list and remove any suspicious actions
-3. **Understand opt-in behavior**: Remember that without `action-list:` in your config, this rule will not run—all actions are allowed
-4. **Use wildcards wisely**: Balance security with maintenance overhead
-   - `actions/checkout@*` - Flexible, allows version updates
-   - `actions/checkout@v4` - Strict, requires config updates for new versions
-5. **Regular updates**: Periodically regenerate and review your action list
+The configuration has no key for a deny list, so no action can be named here for rejection.
+That limit is sisakulint's: GitHub's own repository and organization settings can allow or block
+selected actions and reusable workflows, which is a separate enforcement layer with its own
+scope (see References). What happens when you write a deny list into this file depends on where
+you write it, and the two cases differ:
 
-### See Also
+- A **top-level** `blacklist:` key is an unknown key. It is ignored, the run proceeds, and the
+  entry has no effect.
+- `action-list:` carrying a **nested** `whitelist:` / `blacklist:` map is **rejected**.
+  `action-list` is read as a list of strings, so a map there fails the whole configuration: the
+  run exits 3 without linting anything.
 
-**Industry References:**
-- [Black Hat USA 2025: tj-actions Supply Chain Breach Analysis](https://www.stepsecurity.io/blog/when-changed-files-changed-everything-our-black-hat-2025-presentation-on-the-tj-actions-supply-chain-breach) - Real-world case study demonstrating the need for action allowlists
-- [OWASP Top 10 CI/CD Security Risks: CICD-SEC-08](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-08-Ungoverned-Usage-of-3rd-Party-Services) - Ungoverned Usage of 3rd Party Services
+`sisakulint -init` emits the second shape, under the comment "You can define a whitelist (only
+these actions are allowed) or a blacklist (these actions are blocked)". Following that comment
+does not leave the deny list inert — it stops the tool.
 
-{{< popup_link2 href="https://www.stepsecurity.io/blog/when-changed-files-changed-everything-our-black-hat-2025-presentation-on-the-tj-actions-supply-chain-breach" >}}
+### Watch where the configuration file goes
 
-{{< popup_link2 href="https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-08-Ungoverned-Usage-of-3rd-Party-Services" >}}
+`sisakulint -init` writes the configuration to `.github/action.yaml`, but repository
+auto-discovery reads `.github/sisakulint.yaml`, falling back to `.github/sisakulint.yml`.
+Leaving the file produced by `-init` where it lands does not make this rule work. Pointing
+`-config-file` at it does not either: it ends with a bare tab character, which fails to parse,
+and once that is removed its nested `action-list` fails on the type (see above). Both exit 3.
+
+`sisakulint -generate-action-list` is the working way in. It reads the workflows already in
+`.github/workflows/`, writes `.github/sisakulint.yaml` — the path auto-discovery reads — and the
+rule works from there. Note what it writes: one entry per reference, each ending in `@*`, so the
+generated list names providers and leaves every version free. Narrow the entries you care about
+afterwards (see Remediation).
+
+Writing the file by hand works too, in this form.
+
+```yaml
+action-list:
+  - actions/checkout@*
+```
+
+### The configuration file is part of the control
+
+A pattern such as `*` covers every reference, so a finding can be cleared by editing the
+configuration rather than the workflow — and one change can do both.
+
+The rule reads the configuration it is given and does not compare it with an earlier state, so it
+reports nothing about that edit. Whether the file is reviewed, and whether the list stays
+non-empty and free of a catch-all pattern, is settled outside sisakulint — by who may change that
+file, and by whatever runs alongside the lint.
+
+### Writing patterns
+
+| pattern | matches `actions/checkout@<sha>`? |
+|---|:---:|
+| `actions/checkout@*` | yes |
+| `actions/*` | yes |
+| `*` | yes (allows everything — effectively disabled) |
+
+## References
+
+- [GitHub: Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
+- [GitHub: Managing GitHub Actions settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)
+- [OWASP: CICD-SEC-03 - Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+- [Rule source (`v0.3.6`)](https://github.com/sisaku-security/sisakulint/blob/v0.3.6/pkg/core/actionlist.go)

--- a/content/docs/rules/actionlist.md
+++ b/content/docs/rules/actionlist.md
@@ -254,9 +254,40 @@ file, and by whatever runs alongside the lint.
 | `actions/*` | yes |
 | `*` | yes (allows everything — effectively disabled) |
 
+### Where the allowlist recommendation comes from
+
+The briefing StepSecurity gave at Black Hat USA 2025 on the `tj-actions/changed-files` compromise
+ends with four recommendations, and one of them is "Enforce an Action Allowlist". This rule is a
+check of that kind. What makes curation a control at all is scale: "With over 25,000 actions in
+the GitHub Marketplace, curation is essential."
+
+What that briefing reports about the incident:
+
+- The action was "actively used in over 23,000 public repositories, including those belonging to
+  GitHub, Hugging Face, HashiCorp, Meta, and Microsoft".
+- The attackers used "imposter commits", which live in a fork rather than in the target
+  repository. Since "release tags can point to these ghost commits", the code ran while the
+  repository's own history stayed clean.
+- The payload "dumped the memory of the Runner.Worker process", which holds the secrets a run is
+  given, and those secrets left through the build log.
+
+A list would not by itself have stopped this one. The reference written in the workflow never
+changed. The tag it named was repointed underneath it, and a pattern naming the provider matches
+the compromised reference exactly as it matches the honest one. That is the other axis, and it is
+another of the same four recommendations: "Organizations using commit SHAs instead of mutable
+tags were not affected by this incident" (see Security Background, and `commit-sha`).
+
+OWASP's Top 10 CI/CD Security Risks counts using a marketplace action as granting a third party
+access to the pipeline. Under CICD-SEC-08 the risk covers "installing a plugin from the build
+system’s marketplace (e.g. actions in Github Actions, Orbs in CircleCI)", and its recommendations
+are governance controls over the whole lifecycle of such a dependency (approval, visibility over
+ongoing usage, deprovisioning). A list held in one repository covers part of the first.
+
 ## References
 
 - [GitHub: Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
 - [GitHub: Managing GitHub Actions settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)
 - [OWASP: CICD-SEC-03 - Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+- [OWASP: CICD-SEC-08 - Ungoverned Usage of 3rd Party Services](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-08-Ungoverned-Usage-of-3rd-Party-Services)
+- [StepSecurity: our Black Hat 2025 presentation on the tj-actions supply chain breach](https://www.stepsecurity.io/blog/when-changed-files-changed-everything-our-black-hat-2025-presentation-on-the-tj-actions-supply-chain-breach)
 - [Rule source (`v0.3.6`)](https://github.com/sisaku-security/sisakulint/blob/v0.3.6/pkg/core/actionlist.go)


### PR DESCRIPTION
# docs(actionlist): rewrite the page against the pinned implementation

## What

Rewrites `content/docs/rules/actionlist.md`. One file. The page URL and `weight` are unchanged.

## How it was produced

Written from the implementation rather than edited from the current page:

1. `pkg/core/actionlist.go` read in full at sisakulint
   `dea1408b296a54edc30206ee844daf5ea185b79e` (v0.3.6), together with the configuration loader
   and the list generator.
2. Every claim checked back against that source and against runs of the binary built from it.
3. The page's own examples executed against that binary — for this rule an example is a pair, a
   workflow **and** a configuration, because nothing is reported without one.
4. Five perspectives of external review run over the draft (internal consistency, is/ought,
   knowledge-of-the-curse, external grounding, redundancy). Three factual corrections came out of
   the grounding pass and are in this rewrite.

## What was verified

- **Example Output is byte-identical** to what `dea1408b` prints for the page's own detected
  example. The vulnerable pair reports exactly one `action-list` finding; the safe pair reports
  none, while other rules still fire on it.
- `-generate-action-list` was run end to end: it writes `.github/sisakulint.yaml`, the generated
  list is read, and an unlisted reference added afterwards is reported.
- `hugo` builds the site with this page in place: exit 0, 142 generated pages, no unresolved
  `ref` and no warning beyond the deprecation notices the tree already emits. The same build with
  the current page produces the same counts and the same warnings, so this page changes neither.

## What changed in substance

Against the page as it stands:

- **Section names follow the canonical set.** Overview / Detection Scope / Remediation / the two
  examples / Example Output / Security Impact / Security Background / Attack Scenario / Related
  Rules / Rule Specific Guide / References.
- **Added — the deny side, and what happens if you write one.** There is no deny key. A
  **top-level** `blacklist:` is an unknown key and is ignored; `action-list:` carrying a
  **nested** `whitelist:` / `blacklist:` map fails the whole configuration and the run exits 3
  without linting anything. `-init` emits the second shape, so following its own comment stops
  the tool rather than leaving the deny list inert.
- **Added — where `-init` writes.** `.github/action.yaml`, which repository auto-discovery does
  not read. Pointing `-config-file` at that file does not work either: it ends with a bare tab.
  (This describes v0.3.6. `main` already fixes it — sisaku-security/sisakulint#578.)
- **Added — `jobs.<job_id>.uses` is not matched against the list.** The rule walks a job's steps,
  so a called reusable workflow, and the actions inside it, fall outside the allow-list. Filed
  separately as sisaku-security/sisakulint#616; the page states the boundary.
- **Added — the configuration file is part of the control.** Absent file, empty list, and a
  catch-all pattern all clear findings, and the rule does not compare the configuration with an
  earlier state.
- **Changed — `-generate-action-list` is described with what it produces.** Every generated entry
  ends in `@*`, so the list names providers and leaves versions free.
- **Changed — Remediation leads with review.** Look at the provider, at what the step passes, and
  at what the job's `permissions:` grant, then add the narrowest pattern; a full-length SHA
  matched exactly is the narrowest form.
- **`Severity` and implementation vocabulary are dropped.** The tool prints no severity for this
  rule, and the page no longer names Go types.
- **Kept — the tj-actions background, rebuilt from the primary sources.** The first draft of this
  rewrite dropped `Feature Background` along with the two references it carried, which was a
  mistake on my side rather than a decision. The material is back, under Rule Specific Guide, and
  it now quotes the StepSecurity Black Hat 2025 write-up and OWASP CICD-SEC-08 directly instead of
  paraphrasing them, so each figure can be checked against its source. One point is stated that
  the earlier text did not: an allowlist alone would not have stopped this incident, because the
  reference in the workflow never changed and a provider-only pattern matches the compromised
  reference as readily as the honest one. Pinning is the other axis, and it is another of the same
  four recommendations. Both references are back in `References`.

## Relation to earlier PRs

#10 (`selfhostedrunners`) landed the same rewrite treatment for one page. This is the second, and
the series goes one document per PR so an unsettled question stops that page rather than all of
them.

## Residual risk

The text was produced with LLM assistance. The procedure above ties the factual claims to the
implementation and to real output, and the mechanical parts are checked automatically. Even so,
the possibility of errors in some wording cannot be completely excluded.

Corrections will be sent as follow-up PRs as they are found — the external grounding pass caught
three statements in this page's own draft that way before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
